### PR TITLE
Add install.sh and CLI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The working reference point is tools like Claude Code: fast, agent-driven, termi
 ./install.sh
 ```
 
-This installs dependencies, builds the app, and adds a `face` command to your PATH.
+This installs dependencies, builds the app, and adds a `face` command to `~/.local/bin`. Override the install location with `BIN_DIR=/your/path ./install.sh`.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,15 @@
 set -euo pipefail
 
 FACE_DIR="${FACE_DIR:-$HOME/.face}"
-BIN_DIR="${BIN_DIR:-/usr/local/bin}"
+BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
+
+# Check prerequisites
+for cmd in node npm; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
 
 echo "Installing FACE..."
 
@@ -13,44 +21,54 @@ npm install
 npm run build
 
 # Create data directory
-mkdir -p "$FACE_DIR/tasks"
+mkdir -p "$FACE_DIR" "$BIN_DIR"
 
 # Create the face launcher script
-cat > "$BIN_DIR/face" <<'LAUNCHER'
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cat > "$BIN_DIR/face" <<LAUNCHER
 #!/usr/bin/env bash
 set -euo pipefail
 
-FACE_ROOT="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0")")/../share/face" 2>/dev/null && pwd)"
-if [ -z "$FACE_ROOT" ] || [ ! -d "$FACE_ROOT" ]; then
-  FACE_ROOT="FACE_INSTALL_DIR"
-fi
+FACE_ROOT="$SCRIPT_DIR"
+FACE_DIR="\${FACE_DIR:-\$HOME/.face}"
+PORT="\${PORT:-3456}"
+PID_FILE="\$FACE_DIR/face.pid"
 
-PORT="${PORT:-3456}"
-
-case "${1:-start}" in
+case "\${1:-start}" in
   start)
-    cd "$FACE_ROOT"
-    exec npx next start -p "$PORT"
+    cd "\$FACE_ROOT"
+    echo \$\$ > "\$PID_FILE"
+    exec npx next start --port "\$PORT"
     ;;
   dev)
-    cd "$FACE_ROOT"
-    exec npx next dev --port "$PORT"
+    cd "\$FACE_ROOT"
+    echo \$\$ > "\$PID_FILE"
+    exec npx next dev --port "\$PORT"
     ;;
   stop)
-    pkill -f "next start -p $PORT" 2>/dev/null || pkill -f "next dev --port $PORT" 2>/dev/null || true
+    if [ -f "\$PID_FILE" ]; then
+      pid=\$(cat "\$PID_FILE")
+      if kill -0 "\$pid" 2>/dev/null; then
+        kill "\$pid"
+      fi
+      rm -f "\$PID_FILE"
+    fi
     echo "FACE stopped."
     ;;
+  -h|--help|help)
+    echo "Usage: face [start|dev|stop|help]"
+    echo ""
+    echo "  start   Start the dashboard (default)"
+    echo "  dev     Start in development mode"
+    echo "  stop    Stop the running server"
+    echo "  help    Show this help message"
+    ;;
   *)
-    echo "Usage: face [start|dev|stop]"
+    echo "Usage: face [start|dev|stop|help]" >&2
     exit 1
     ;;
 esac
 LAUNCHER
-
-# Patch in the actual install directory
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-sed -i.bak "s|FACE_INSTALL_DIR|$SCRIPT_DIR|g" "$BIN_DIR/face"
-rm -f "$BIN_DIR/face.bak"
 
 chmod +x "$BIN_DIR/face"
 
@@ -61,3 +79,10 @@ echo "  face        Start the dashboard (http://localhost:3456)"
 echo "  face dev    Start in development mode"
 echo "  face stop   Stop the running server"
 echo ""
+
+# Remind user to add BIN_DIR to PATH if needed
+if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
+  echo "Note: Add $BIN_DIR to your PATH:"
+  echo "  export PATH=\"$BIN_DIR:\$PATH\""
+  echo ""
+fi


### PR DESCRIPTION
## Summary
- Add `install.sh` that installs deps, builds the app, and places a `face` command on PATH
- Update README with install and CLI usage instructions (`face`, `face dev`, `face stop`)

## Test plan
- [ ] Run `./install.sh` and verify it completes without errors
- [ ] Run `face` and confirm the server starts on port 3456
- [ ] Run `face dev` and confirm dev mode starts
- [ ] Run `face stop` and confirm the server stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)