### PR TITLE
Add drag-and-drop to board view

### DIFF
--- a/src/components/project/BoardView.tsx
+++ b/src/components/project/BoardView.tsx
@@ -37,6 +37,8 @@ export function BoardView({ onSelectIssue, onAssignAgent }: Props) {
   const [columns, setColumns] = useState<ColumnData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [draggingIssueId, setDraggingIssueId] = useState<string | null>(null);
+  const [dropTargetColumn, setDropTargetColumn] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchBoard = () => {
@@ -57,6 +59,69 @@ export function BoardView({ onSelectIssue, onAssignAgent }: Props) {
     const interval = setInterval(fetchBoard, 30_000);
     return () => clearInterval(interval);
   }, []);
+
+  const handleDragOver = (e: React.DragEvent, columnId: string) => {
+    e.preventDefault();
+    setDropTargetColumn(columnId);
+  };
+
+  const handleDragLeave = (e: React.DragEvent, columnId: string) => {
+    // Only clear if leaving the column itself, not entering a child
+    const relatedTarget = e.relatedTarget as HTMLElement | null;
+    const currentTarget = e.currentTarget as HTMLElement;
+    if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
+      setDropTargetColumn((prev) => (prev === columnId ? null : prev));
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent, targetColumn: ColumnData) => {
+    e.preventDefault();
+    setDropTargetColumn(null);
+    setDraggingIssueId(null);
+
+    const issueId = e.dataTransfer.getData("text/plain");
+    if (!issueId) return;
+
+    // Find the source column and issue
+    const sourceColumn = columns.find((col) =>
+      col.issues.some((issue) => issue.id === issueId)
+    );
+    if (!sourceColumn || sourceColumn.id === targetColumn.id) return;
+
+    const issue = sourceColumn.issues.find((i) => i.id === issueId);
+    if (!issue) return;
+
+    // Optimistic update
+    const previousColumns = columns;
+    setColumns((prev) =>
+      prev.map((col) => {
+        if (col.id === sourceColumn.id) {
+          return { ...col, issues: col.issues.filter((i) => i.id !== issueId) };
+        }
+        if (col.id === targetColumn.id) {
+          return {
+            ...col,
+            issues: [...col.issues, { ...issue, status: targetColumn.status }],
+          };
+        }
+        return col;
+      })
+    );
+
+    // Persist via API
+    fetch(`/api/project/issues/${issueId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: targetColumn.status }),
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to update issue status");
+      })
+      .catch(() => {
+        // Revert on error
+        setColumns(previousColumns);
+      });
+  };
 
   if (loading) {
     return (
@@ -86,7 +151,14 @@ export function BoardView({ onSelectIssue, onAssignAgent }: Props) {
         {columns.map((col) => (
           <div
             key={col.id}
-            className="min-w-[280px] max-w-[320px] flex-shrink-0 bg-zinc-900 rounded-lg border border-zinc-800"
+            onDragOver={(e) => handleDragOver(e, col.id)}
+            onDragLeave={(e) => handleDragLeave(e, col.id)}
+            onDrop={(e) => handleDrop(e, col)}
+            className={`min-w-[280px] max-w-[320px] flex-shrink-0 bg-zinc-900 rounded-lg border transition-colors ${
+              dropTargetColumn === col.id
+                ? "border-indigo-500 bg-indigo-500/5"
+                : "border-zinc-800"
+            }`}
           >
             <div className="px-3 py-2.5 border-b border-zinc-800 flex items-center gap-2">
               <span className={`w-2 h-2 rounded-full ${STATUS_DOT[col.status] ?? "bg-zinc-500"}`} />
@@ -102,6 +174,16 @@ export function BoardView({ onSelectIssue, onAssignAgent }: Props) {
                   issue={issue}
                   onSelect={() => onSelectIssue(issue.id)}
                   onAssignAgent={() => onAssignAgent(issue.id)}
+                  isDragging={draggingIssueId === issue.id}
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData("text/plain", issue.id);
+                    e.dataTransfer.effectAllowed = "move";
+                    setDraggingIssueId(issue.id);
+                  }}
+                  onDragEnd={() => {
+                    setDraggingIssueId(null);
+                    setDropTargetColumn(null);
+                  }}
                 />
               ))}
               {col.issues.length === 0 && (
@@ -119,15 +201,26 @@ function IssueCard({
   issue,
   onSelect,
   onAssignAgent,
+  isDragging,
+  onDragStart,
+  onDragEnd,
 }: {
   issue: Issue;
   onSelect: () => void;
   onAssignAgent: () => void;
+  isDragging: boolean;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
 }) {
   return (
     <div
+      draggable="true"
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       onClick={onSelect}
-      className="p-3 bg-zinc-850 bg-zinc-800/50 rounded-md border border-zinc-700/50 hover:border-zinc-600 cursor-pointer transition-colors group"
+      className={`p-3 bg-zinc-850 bg-zinc-800/50 rounded-md border border-zinc-700/50 hover:border-zinc-600 cursor-pointer transition-colors group ${
+        isDragging ? "opacity-50" : ""
+      }`}
     >
       <div className="flex items-start justify-between gap-2">
         <span className="text-xs text-zinc-500 font-mono">#{issue.number}</span>


### PR DESCRIPTION
## Summary
- Add HTML5 drag-and-drop support to the board view for moving issue cards between status columns
- Optimistic UI updates with automatic revert on API failure
- Visual feedback: dragged card gets reduced opacity, drop target column gets indigo highlight border

Closes #10

## Test plan
- [ ] Drag an issue card from one column to another and verify it moves immediately
- [ ] Verify the PATCH API call is made with the correct new status
- [ ] Simulate a network error and confirm the card reverts to its original column
- [ ] Confirm drop target column highlights with indigo border during drag-over
- [ ] Confirm dragged card shows reduced opacity
- [ ] Verify dropping on the same column is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)