### PR TITLE
Enhance agent auto-comments on GitHub issues

### DIFF
--- a/src/lib/tasks/github-notify.ts
+++ b/src/lib/tasks/github-notify.ts
@@ -26,6 +26,16 @@ export async function postCompletionComment(task: FaceTask): Promise<void> {
     console.log(
       `[face] Posted completion comment on issue #${task.linkedIssue} for task ${task.id}`
     );
+
+    // Update issue status when task completed successfully
+    if (task.status === "completed") {
+      try {
+        await provider.updateIssue(String(task.linkedIssue), { status: "in_review" });
+        console.log(`[face] Updated issue #${task.linkedIssue} status to in_review`);
+      } catch (err) {
+        console.error(`[face] Failed to update issue #${task.linkedIssue} status:`, err);
+      }
+    }
   } catch (err) {
     console.error(
       `[face] Failed to post GitHub comment on issue #${task.linkedIssue} for task ${task.id}:`,
@@ -58,6 +68,9 @@ function buildCommentBody(task: FaceTask): string {
   if (task.title) {
     lines.push(`**Task:** ${task.title}`);
   }
+
+  lines.push("");
+  lines.push(`[View full task details in FACE](http://localhost:3000/project?task=${task.id})`);
 
   if (task.summary) {
     lines.push("");


### PR DESCRIPTION
## Summary
- Add FACE dashboard link to agent completion comments posted on GitHub issues, so users can click through to see full task details
- Automatically update linked issue status to `in_review` when an agent task completes successfully
- Non-critical failures (status update) are caught and logged without affecting the comment posting flow

Closes #11

## Test plan
- [ ] Trigger an agent task linked to a GitHub issue and verify the completion comment includes a "View full task details in FACE" link
- [ ] Verify that on successful task completion, the linked issue status is updated to `in_review`
- [ ] Verify that on failed task completion, the issue status is NOT updated
- [ ] Verify that if the status update fails, the comment is still posted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)