### PR TITLE
Fix SSE stream initialization error on startup

### DIFF
--- a/src/app/api/project/events/route.ts
+++ b/src/app/api/project/events/route.ts
@@ -4,6 +4,8 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   const encoder = new TextEncoder();
+  let cleanup: (() => void) | null = null;
+
   const stream = new ReadableStream({
     start(controller) {
       const send = (event: string, data: unknown) => {
@@ -27,8 +29,7 @@ export async function GET() {
       eventBus.on("agent_started", onAgentStarted);
       eventBus.on("agent_completed", onAgentCompleted);
 
-      // Cleanup on close
-      const cleanup = () => {
+      cleanup = () => {
         clearInterval(heartbeat);
         eventBus.off("issue_created", onIssueCreated);
         eventBus.off("issue_updated", onIssueUpdated);
@@ -36,15 +37,10 @@ export async function GET() {
         eventBus.off("agent_completed", onAgentCompleted);
       };
 
-      // The stream will be closed by the client or server; use signal if available
       controller.enqueue(encoder.encode(": connected\n\n"));
-
-      // Store cleanup so it can be called
-      (stream as any).__cleanup = cleanup;
     },
     cancel() {
-      // Called when the client disconnects
-      if ((stream as any).__cleanup) (stream as any).__cleanup();
+      cleanup?.();
     },
   });
 


### PR DESCRIPTION
## Summary
- Fixes `ReferenceError: Cannot access 'stream' before initialization` in the SSE events endpoint
- The `start()` callback of `ReadableStream` runs synchronously during construction, so `stream` (declared with `const`) wasn't assigned yet when referenced inside `start()`
- Moved cleanup function to a hoisted `let` variable in the outer scope

## Test plan
- [ ] Start the dev server and verify no `ReferenceError` on `/api/project/events`
- [ ] Confirm SSE events stream connects successfully (`: connected` message sent)
- [ ] Navigate away and confirm cleanup runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)