### PR TITLE
Move dashboard to /tasks route

### DIFF
--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -26,9 +26,17 @@ export function TaskRow({
       : null;
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => onSelectAction(task.id)}
-      className={`w-full text-left rounded-lg border p-3 transition-all ${
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelectAction(task.id);
+        }
+      }}
+      className={`w-full text-left rounded-lg border p-3 transition-all cursor-pointer ${
         selected
           ? "border-blue-700 bg-blue-950/30 shadow-lg shadow-blue-900/10"
           : "border-zinc-800 bg-zinc-900 hover:border-zinc-700 hover:bg-zinc-900/80"
@@ -88,6 +96,6 @@ export function TaskRow({
           <div className="h-full rounded-full bg-blue-500 transition-all animate-pulse" style={{ width: "60%" }} />
         </div>
       )}
-    </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Moved the main dashboard page from `/` to `/tasks` for a clearer URL structure
- Root `/` now redirects to `/tasks` using Next.js `redirect()`
- Updated the ProjectSidebar back-link to point to `/tasks` instead of `/`

## Test plan
- [ ] Visit `/` and verify it redirects to `/tasks`
- [ ] Visit `/tasks` directly and verify the dashboard loads correctly (agent detection, setup flow, task list)
- [ ] Navigate from `/project` back to dashboard via sidebar link and verify it goes to `/tasks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)