### PR TITLE
Fix gathering prompt to skip unnecessary questions for clear requests

### DIFF
--- a/src/lib/project/workflow.ts
+++ b/src/lib/project/workflow.ts
@@ -107,10 +107,11 @@ export function buildGatheringSystemPrompt(): string {
   return `You are a senior technical product manager AI assistant. Your job is to help the user refine a software requirement into a clear, actionable story.
 
 RULES:
-- Ask clarifying questions ONE AT A TIME to understand the requirement fully
-- Focus on: user impact, acceptance criteria, edge cases, technical constraints
-- When you have enough information (usually 3-5 exchanges), say EXACTLY: "[READY_TO_PLAN]" at the end of your message
-- Keep responses concise — 2-3 sentences per question
+- If the user's message is already detailed and actionable (clear goal, scope, and steps), acknowledge the plan briefly and include "[READY_TO_PLAN]" in your FIRST response — do not ask unnecessary questions
+- Only ask clarifying questions when the requirement is genuinely vague or ambiguous
+- Ask at most one question at a time; focus on: user impact, acceptance criteria, edge cases, technical constraints
+- When you have enough information, say EXACTLY: "[READY_TO_PLAN]" at the end of your message — this can be after 1 exchange or up to 5, whatever the requirement needs
+- Keep responses concise — 2-3 sentences max
 - Don't write the story yet, just gather information`;
 }
 


### PR DESCRIPTION
## Summary
- The gathering phase AI always asked 3-5 clarifying questions before signaling `[READY_TO_PLAN]`, even when the user's first message was already a complete, actionable request
- Updated `buildGatheringSystemPrompt()` to instruct the AI to recognize detailed requests and emit `[READY_TO_PLAN]` immediately, only asking clarifying questions when the requirement is genuinely vague

## Test plan
- [ ] Send a detailed, actionable request (e.g. "check the repo, update the project info, break down the epics to tasks, create tickets, and start the implement loop") and verify `[READY_TO_PLAN]` appears in the first AI response
- [ ] Send a vague request (e.g. "I want to add a new feature") and verify the AI asks a clarifying question instead of immediately signaling ready
- [ ] Verify the workflow still transitions correctly from gathering to planning phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)