### PR TITLE
Fix task list scroll overflow

### DIFF
--- a/src/components/layout/AdaptiveShell.tsx
+++ b/src/components/layout/AdaptiveShell.tsx
@@ -27,7 +27,7 @@ export function AdaptiveShell() {
           </div>
         </AdaptiveFeature>
         {/* Task list */}
-        <AdaptiveFeature featureId="task-list" alwaysShow>
+        <AdaptiveFeature featureId="task-list" alwaysShow className="flex-1 min-h-0 overflow-hidden">
           <TaskList />
         </AdaptiveFeature>
       </main>

--- a/src/components/shared/AdaptiveFeature.tsx
+++ b/src/components/shared/AdaptiveFeature.tsx
@@ -12,6 +12,8 @@ interface AdaptiveFeatureProps {
   alwaysShow?: boolean;
   /** Render collapsed version when hidden (e.g. a "Show more" link) */
   collapsedContent?: ReactNode;
+  /** Additional CSS classes for the wrapper div */
+  className?: string;
 }
 
 export function AdaptiveFeature({
@@ -20,6 +22,7 @@ export function AdaptiveFeature({
   trackOnView = false,
   alwaysShow = false,
   collapsedContent,
+  className,
 }: AdaptiveFeatureProps) {
   const { isFeatureVisible, isFeaturePinned, trackFeature, getFeatureScore } =
     useUser();
@@ -53,7 +56,7 @@ export function AdaptiveFeature({
       onClick={() => trackFeature(featureId)}
       className={`transition-opacity duration-300 ${
         pinned ? "opacity-100" : score < 0.5 ? "opacity-70" : "opacity-90"
-      }`}
+      }${className ? ` ${className}` : ""}`}
     >
       {children}
     </div>

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -44,7 +44,7 @@ export function TaskList() {
   return (
     <div className="flex flex-col lg:flex-row flex-1 gap-4 min-h-0">
       {/* Task list column */}
-      <div className="flex flex-col w-full lg:w-72 xl:w-80 lg:flex-shrink-0">
+      <div className="flex flex-col w-full lg:w-72 xl:w-80 lg:flex-shrink-0 min-h-0">
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-xs font-semibold uppercase tracking-wider text-zinc-500">
             Tasks
@@ -64,7 +64,7 @@ export function TaskList() {
             <option value="failed">Failed</option>
           </select>
         </div>
-        <div className="space-y-2 overflow-y-auto flex-1 max-h-48 lg:max-h-none">
+        <div className="space-y-2 overflow-y-auto flex-1 min-h-0">
           {filtered.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-zinc-600">
               <svg className="h-8 w-8 mb-3 text-zinc-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">


### PR DESCRIPTION
## Summary
- Task list was not scrollable when many tasks were present due to `max-h-48` capping the container at 192px on mobile and the `AdaptiveFeature` wrapper not participating in flex layout
- Added `className` prop to `AdaptiveFeature` component so parent layout classes can be passed through
- Applied `flex-1 min-h-0 overflow-hidden` on the task-list `AdaptiveFeature` wrapper and replaced `max-h-48` with `min-h-0` on the scrollable task list container

## Test plan
- [ ] Open the dashboard with many tasks (10+) and verify the task list scrolls on both mobile and desktop viewports
- [ ] Verify the task detail panel still displays correctly when a task is selected
- [ ] Confirm no layout regressions on the task submission area above the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)