### PR TITLE
Fix streaming task progress in TaskStatusPanel

### DIFF
--- a/src/components/project/TaskStatusPanel.tsx
+++ b/src/components/project/TaskStatusPanel.tsx
@@ -61,7 +61,10 @@ export function TaskStatusPanel({ taskId, onStatusChange }: Props) {
   const [task, setTask] = useState<TaskData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expandedSection, setExpandedSection] = useState<"activities" | "steps" | "result" | null>("activities");
+  const [expandedSection, setExpandedSection] = useState<"activities" | "steps" | "result" | null>(null);
+  // Default to steps when there are steps but no activities
+  const defaultSection = task?.activities?.length ? "activities" : task?.steps?.length ? "steps" : null;
+  const activeSection = expandedSection ?? defaultSection;
 
   // Single polling effect — fetches immediately, then every 3s until terminal
   useEffect(() => {
@@ -161,6 +164,28 @@ export function TaskStatusPanel({ taskId, onStatusChange }: Props) {
       )}
 
       {/* Progress bar for running tasks */}
+      {isActive && task.steps.length > 0 && task.activities.length === 0 && (
+        <div className="px-4 py-2 border-b border-zinc-800">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 h-1 bg-zinc-800 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-amber-500 rounded-full transition-all duration-500"
+                style={{
+                  width: `${Math.min(
+                    (task.steps.filter((s) => s.status === "completed").length /
+                      Math.max(task.steps.length, 1)) *
+                      100,
+                    95
+                  )}%`,
+                }}
+              />
+            </div>
+            <span className="text-[10px] text-zinc-500">
+              {task.steps.filter((s) => s.status === "completed").length}/{task.steps.length} steps
+            </span>
+          </div>
+        </div>
+      )}
       {isActive && task.activities.length > 0 && (
         <div className="px-4 py-2 border-b border-zinc-800">
           <div className="flex items-center gap-2">
@@ -191,8 +216,8 @@ export function TaskStatusPanel({ taskId, onStatusChange }: Props) {
           <CollapsibleSection
             title="Activities"
             count={task.activities.length}
-            expanded={expandedSection === "activities"}
-            onToggle={() => setExpandedSection(expandedSection === "activities" ? null : "activities")}
+            expanded={activeSection === "activities"}
+            onToggle={() => setExpandedSection(activeSection === "activities" ? null : "activities")}
           >
             <div className="space-y-1.5 px-4 pb-3">
               {task.activities.map((activity) => (
@@ -236,8 +261,8 @@ export function TaskStatusPanel({ taskId, onStatusChange }: Props) {
           <CollapsibleSection
             title="Recent Steps"
             count={task.steps.length}
-            expanded={expandedSection === "steps"}
-            onToggle={() => setExpandedSection(expandedSection === "steps" ? null : "steps")}
+            expanded={activeSection === "steps"}
+            onToggle={() => setExpandedSection(activeSection === "steps" ? null : "steps")}
           >
             <div className="space-y-1 px-4 pb-3 max-h-48 overflow-y-auto">
               {task.steps.slice(-10).map((step) => (
@@ -263,8 +288,8 @@ export function TaskStatusPanel({ taskId, onStatusChange }: Props) {
         {task.result && (
           <CollapsibleSection
             title="Result"
-            expanded={expandedSection === "result"}
-            onToggle={() => setExpandedSection(expandedSection === "result" ? null : "result")}
+            expanded={activeSection === "result"}
+            onToggle={() => setExpandedSection(activeSection === "result" ? null : "result")}
           >
             <div className="px-4 pb-3">
               <pre className="text-xs text-zinc-300 whitespace-pre-wrap bg-zinc-800/50 rounded p-3 max-h-64 overflow-y-auto font-mono leading-relaxed">

--- a/src/lib/tasks/runner.ts
+++ b/src/lib/tasks/runner.ts
@@ -78,12 +78,38 @@ export async function submitTask(
   return { taskId };
 }
 
+/** Build a human-readable description from a tool_use content block. */
+function describeToolUse(name: string, input: Record<string, unknown>): string {
+  const file =
+    (input.file_path as string) ??
+    (input.path as string) ??
+    (input.filename as string) ??
+    null;
+  const short = file ? file.split("/").pop() : null;
+
+  switch (name) {
+    case "Read":
+      return short ? `Reading ${short}` : "Reading file";
+    case "Write":
+      return short ? `Writing ${short}` : "Writing file";
+    case "Edit":
+      return short ? `Editing ${short}` : "Editing file";
+    case "Bash":
+      return "Running command";
+    case "Grep":
+    case "Glob":
+      return "Searching files";
+    default:
+      return name;
+  }
+}
+
 function spawnClaudeCode(task: FaceTask, binaryPath: string): void {
   const args = [
     "-p",
     task.prompt,
     "--output-format",
-    "json",
+    "stream-json",
   ];
 
   // Allowlist env vars — don't leak secrets to child processes
@@ -105,11 +131,90 @@ function spawnClaudeCode(task: FaceTask, binaryPath: string): void {
   runningTasks.set(task.id, child);
 
   const MAX_OUTPUT = 2 * 1024 * 1024; // 2MB cap
-  let stdout = "";
   let stderr = "";
+  let lineBuf = ""; // buffer for partial lines from stdout
+  let stepIndex = 0;
+  let lastWriteAt = 0;
+  const WRITE_THROTTLE_MS = 1000;
+
+  /** Persist task to disk (throttled — at most once per second). */
+  function throttledWrite(force?: boolean) {
+    const now = Date.now();
+    if (!force && now - lastWriteAt < WRITE_THROTTLE_MS) return;
+    lastWriteAt = now;
+    task.updatedAt = new Date().toISOString();
+    writeTask(task);
+    eventBus.emit("task-file-changed", {
+      event: "change",
+      filename: `${task.id}.json`,
+    });
+  }
+
+  /** Mark the most recent running step as completed. */
+  function completeCurrentStep() {
+    const running = task.steps.findLast((s) => s.status === "running");
+    if (running) {
+      running.status = "completed";
+    }
+  }
+
+  /** Process a single parsed stream-json event. */
+  function handleStreamEvent(evt: Record<string, unknown>) {
+    if (evt.type === "assistant") {
+      const msg = evt.message as { content?: Array<Record<string, unknown>> } | undefined;
+      if (!msg?.content) return;
+
+      for (const block of msg.content) {
+        if (block.type === "tool_use") {
+          // Mark any previous running step as completed
+          completeCurrentStep();
+
+          const toolName = (block.name as string) ?? "unknown";
+          const toolInput = (block.input as Record<string, unknown>) ?? {};
+          const description = describeToolUse(toolName, toolInput);
+
+          task.steps.push({
+            id: `step-${stepIndex++}`,
+            tool: toolName,
+            description,
+            status: "running",
+            timestamp: new Date().toISOString(),
+          });
+
+          task.summary = description;
+          throttledWrite();
+        }
+      }
+    } else if (evt.type === "result") {
+      // Final event — complete last step and capture result
+      completeCurrentStep();
+      const resultText = (evt.result as string) ?? "";
+      task.result = resultText;
+      task.summary = resultText.slice(0, 200) || task.summary;
+      // Will be written on close, no need to throttle here
+    }
+  }
 
   child.stdout?.on("data", (data: Buffer) => {
-    if (stdout.length < MAX_OUTPUT) stdout += data.toString();
+    lineBuf += data.toString();
+    if (lineBuf.length > MAX_OUTPUT) {
+      lineBuf = lineBuf.slice(-MAX_OUTPUT);
+    }
+
+    // Process complete lines (newline-delimited JSON)
+    let newlineIdx: number;
+    while ((newlineIdx = lineBuf.indexOf("\n")) !== -1) {
+      const line = lineBuf.slice(0, newlineIdx).trim();
+      lineBuf = lineBuf.slice(newlineIdx + 1);
+      if (!line) continue;
+
+      try {
+        const evt = JSON.parse(line) as Record<string, unknown>;
+        handleStreamEvent(evt);
+      } catch {
+        // Not valid JSON — ignore (could be stray stderr or partial line)
+      }
+    }
   });
 
   child.stderr?.on("data", (data: Buffer) => {
@@ -119,16 +224,24 @@ function spawnClaudeCode(task: FaceTask, binaryPath: string): void {
   child.on("close", (code) => {
     runningTasks.delete(task.id);
 
+    // Process any remaining partial line in the buffer
+    if (lineBuf.trim()) {
+      try {
+        const evt = JSON.parse(lineBuf.trim()) as Record<string, unknown>;
+        handleStreamEvent(evt);
+      } catch {
+        // ignore
+      }
+    }
+
+    completeCurrentStep();
+
     task.status = code === 0 ? "completed" : "failed";
     task.updatedAt = new Date().toISOString();
 
-    // Try to parse JSON output
-    try {
-      const result = JSON.parse(stdout);
-      task.result = result.result ?? stdout;
-      task.summary = result.result?.slice(0, 200) ?? null;
-    } catch {
-      task.result = stdout || stderr || `Process exited with code ${code}`;
+    // If no result was captured from stream events, fall back to stderr
+    if (!task.result) {
+      task.result = stderr || `Process exited with code ${code}`;
     }
 
     writeTask(task);


### PR DESCRIPTION
## Summary
- Switch `spawnClaudeCode()` from `--output-format json` to `--output-format stream-json` so Claude Code emits newline-delimited JSON events as it works, instead of a single blob on completion
- Parse `tool_use` content blocks from `assistant` events in real-time to populate `task.steps` with running/completed status and human-readable descriptions (e.g. "Reading runner.ts", "Searching files")
- Throttle task file writes to max once per second to avoid excessive disk I/O while still keeping the polling `TaskStatusPanel` up to date
- Update `TaskStatusPanel` to auto-expand the "Recent Steps" section when steps exist but activities are empty, and add a step-based progress bar for running tasks

## Test plan
- [ ] Start an agent task from the requirement workflow implementing page
- [ ] Verify the TaskStatusPanel shows real-time step updates (tool names, descriptions) while the task runs
- [ ] Verify the progress bar animates as steps complete
- [ ] Verify the summary text updates to reflect current activity
- [ ] Verify task completes successfully with result captured from the `result` stream event
- [ ] Verify a failed task still shows steps collected before the failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)