### PR TITLE
Fix Bash step description to show actual command

### DIFF
--- a/src/app/api/hooks/task-update/route.ts
+++ b/src/app/api/hooks/task-update/route.ts
@@ -191,8 +191,8 @@ function buildStepDescription(
   }
 
   if (t === "bash") {
-    const cmd = String(input.command ?? "").trim();
-    return cmd.slice(0, 120) || "Run command";
+    const cmd = String(input.command ?? input.description ?? "").trim();
+    return cmd.slice(0, 120) || "Running command";
   }
 
   if (t === "glob") {

--- a/src/lib/tasks/__tests__/describeToolUse.test.ts
+++ b/src/lib/tasks/__tests__/describeToolUse.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from "bun:test";
+import { describeToolUse } from "../describe-tool";
+
+describe("describeToolUse", () => {
+  // --- Bash ---
+
+  test("Bash with command shows truncated command", () => {
+    const result = describeToolUse("Bash", { command: "git status" });
+    expect(result).toBe("git status");
+  });
+
+  test("Bash with description fallback shows description", () => {
+    const result = describeToolUse("Bash", { description: "List files" });
+    expect(result).toBe("List files");
+  });
+
+  test("Bash with no input shows 'Running command'", () => {
+    const result = describeToolUse("Bash", {});
+    expect(result).toBe("Running command");
+  });
+
+  test("Bash with very long command is truncated to 120 chars", () => {
+    const longCommand = "a".repeat(200);
+    const result = describeToolUse("Bash", { command: longCommand });
+    expect(result).toHaveLength(120);
+    expect(result).toBe("a".repeat(120));
+  });
+
+  test("Bash prefers command over description", () => {
+    const result = describeToolUse("Bash", {
+      command: "npm test",
+      description: "Run tests",
+    });
+    expect(result).toBe("npm test");
+  });
+
+  // --- Read ---
+
+  test("Read with file_path shows 'Reading filename'", () => {
+    const result = describeToolUse("Read", {
+      file_path: "/src/lib/tasks/runner.ts",
+    });
+    expect(result).toBe("Reading runner.ts");
+  });
+
+  test("Read with no file_path shows generic description", () => {
+    const result = describeToolUse("Read", {});
+    expect(result).toBe("Reading file");
+  });
+
+  // --- Write ---
+
+  test("Write with file_path shows 'Writing filename'", () => {
+    const result = describeToolUse("Write", {
+      file_path: "/src/components/App.tsx",
+    });
+    expect(result).toBe("Writing App.tsx");
+  });
+
+  test("Write with no file_path shows generic description", () => {
+    const result = describeToolUse("Write", {});
+    expect(result).toBe("Writing file");
+  });
+
+  // --- Edit ---
+
+  test("Edit with file_path shows 'Editing filename'", () => {
+    const result = describeToolUse("Edit", {
+      file_path: "/src/lib/utils.ts",
+    });
+    expect(result).toBe("Editing utils.ts");
+  });
+
+  test("Edit with no file_path shows generic description", () => {
+    const result = describeToolUse("Edit", {});
+    expect(result).toBe("Editing file");
+  });
+
+  // --- Grep ---
+
+  test("Grep shows 'Searching content'", () => {
+    const result = describeToolUse("Grep", { pattern: "TODO" });
+    expect(result).toBe("Searching content: TODO");
+  });
+
+  // --- Glob ---
+
+  test("Glob shows 'Searching files'", () => {
+    const result = describeToolUse("Glob", { pattern: "**/*.ts" });
+    expect(result).toBe("Searching files: **/*.ts");
+  });
+
+  // --- Unknown tool ---
+
+  test("Unknown tool returns the tool name", () => {
+    const result = describeToolUse("MyCustomTool", {});
+    expect(result).toBe("MyCustomTool");
+  });
+});

--- a/src/lib/tasks/describe-tool.ts
+++ b/src/lib/tasks/describe-tool.ts
@@ -1,0 +1,28 @@
+/** Build a human-readable description from a tool_use content block. */
+export function describeToolUse(name: string, input: Record<string, unknown>): string {
+  const file =
+    (input.file_path as string) ??
+    (input.path as string) ??
+    (input.filename as string) ??
+    null;
+  const short = file ? file.split("/").pop() : null;
+
+  switch (name) {
+    case "Read":
+      return short ? `Reading ${short}` : "Reading file";
+    case "Write":
+      return short ? `Writing ${short}` : "Writing file";
+    case "Edit":
+      return short ? `Editing ${short}` : "Editing file";
+    case "Bash": {
+      const cmd = String(input.command ?? input.description ?? "").trim();
+      return cmd.slice(0, 120) || "Running command";
+    }
+    case "Grep":
+      return `Searching content: ${input.pattern ?? ""}`.trim();
+    case "Glob":
+      return `Searching files: ${input.pattern ?? ""}`.trim();
+    default:
+      return name;
+  }
+}

--- a/src/lib/tasks/runner.ts
+++ b/src/lib/tasks/runner.ts
@@ -4,6 +4,8 @@ import { writeTask, readAllTasks } from "./file-manager";
 import { eventBus } from "../events/bus";
 import type { FaceTask } from "./types";
 import { postCompletionComment } from "./github-notify";
+export { describeToolUse } from "./describe-tool";
+import { describeToolUse } from "./describe-tool";
 
 // Track running processes globally
 const globalForRunner = globalThis as unknown as {
@@ -96,32 +98,6 @@ export async function submitTask(
   }
 
   return { taskId };
-}
-
-/** Build a human-readable description from a tool_use content block. */
-function describeToolUse(name: string, input: Record<string, unknown>): string {
-  const file =
-    (input.file_path as string) ??
-    (input.path as string) ??
-    (input.filename as string) ??
-    null;
-  const short = file ? file.split("/").pop() : null;
-
-  switch (name) {
-    case "Read":
-      return short ? `Reading ${short}` : "Reading file";
-    case "Write":
-      return short ? `Writing ${short}` : "Writing file";
-    case "Edit":
-      return short ? `Editing ${short}` : "Editing file";
-    case "Bash":
-      return "Running command";
-    case "Grep":
-    case "Glob":
-      return "Searching files";
-    default:
-      return name;
-  }
 }
 
 function spawnClaudeCode(task: FaceTask, binaryPath: string): void {


### PR DESCRIPTION
## Summary
- **Fixed bug** in `describeToolUse` where Bash tool uses returned just `"Running command"`, losing the actual command needed for security auditing. Now shows the truncated command (max 120 chars) with `input.description` as fallback.
- **Extracted** `describeToolUse` into `src/lib/tasks/describe-tool.ts` for testability (runner.ts has module-level side effects that prevent direct testing).
- **Aligned** the hooks-based `buildStepDescription` in `src/app/api/hooks/task-update/route.ts` to also use `input.description` fallback and consistent `"Running command"` default.
- **Updated** Grep/Glob descriptions in runner to include the search pattern (matching hooks version).
- **Added** 14 unit tests covering all tool types, edge cases (empty input, long commands, fallbacks).

## Test plan
- [x] `bun test ./src/lib/tasks/__tests__/describeToolUse.test.ts` — 14 tests pass
- [ ] Verify Bash steps in the UI show actual commands instead of generic "Running command"
- [ ] Verify Grep/Glob steps show search patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)