### PR TITLE
Fix failed task display and add restart from requirements view

### DIFF
--- a/src/app/api/project/workflow/[workflowId]/chat/route.ts
+++ b/src/app/api/project/workflow/[workflowId]/chat/route.ts
@@ -278,6 +278,21 @@ export async function POST(
     return NextResponse.json({ workflow });
   }
 
+  // ── Reopen workflow (failed task → back to implementing) ──────
+  if (body.action === "reopen") {
+    if (workflow.phase !== "done") {
+      return NextResponse.json(
+        { error: "Only done workflows can be reopened" },
+        { status: 400 }
+      );
+    }
+    workflow.phase = "implementing";
+    workflow.taskId = body.taskId ?? workflow.taskId;
+    workflow.updatedAt = new Date().toISOString();
+    saveWorkflow(workflow);
+    return NextResponse.json({ workflow });
+  }
+
   // ── Mark workflow complete ─────────────────────────────────────
   if (body.action === "complete") {
     if (workflow.phase !== "implementing") {

--- a/src/components/project/RequirementWorkflow.tsx
+++ b/src/components/project/RequirementWorkflow.tsx
@@ -281,7 +281,16 @@ export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
 
         {/* Done */}
         {workflow.phase === "done" && (
-          <DoneView workflow={workflow} onClose={onClose} />
+          <DoneView
+            workflow={workflow}
+            onClose={onClose}
+            onReopen={(newTaskId) => {
+              setWorkflow((w) =>
+                w ? { ...w, phase: "implementing", taskId: newTaskId, updatedAt: new Date().toISOString() } : null
+              );
+              onCreated();
+            }}
+          />
         )}
       </div>
 
@@ -718,16 +727,70 @@ function ImplementingView({
   );
 }
 
-function DoneView({ workflow, onClose }: { workflow: WorkflowState; onClose: () => void }) {
+function DoneView({
+  workflow,
+  onClose,
+  onReopen,
+}: {
+  workflow: WorkflowState;
+  onClose: () => void;
+  onReopen: (newTaskId: string) => void;
+}) {
+  const [taskFailed, setTaskFailed] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+
+  const handleStatusChange = useCallback((status: string) => {
+    if (status === "failed" || status === "cancelled") {
+      setTaskFailed(true);
+    }
+  }, []);
+
+  const handleRestart = useCallback(
+    async (taskId: string) => {
+      if (restarting || !workflow.id) return;
+      setRestarting(true);
+      try {
+        // 1. Restart the task
+        const res = await fetch(`/api/tasks/${taskId}/restart`, { method: "POST" });
+        const data = await res.json();
+        if (!data.taskId) return;
+
+        // 2. Reopen the workflow
+        await fetch(`/api/project/workflow/${workflow.id}/chat`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "reopen", taskId: data.taskId }),
+        });
+
+        onReopen(data.taskId);
+      } catch (err) {
+        console.error("Failed to restart implementation:", err);
+      } finally {
+        setRestarting(false);
+      }
+    },
+    [restarting, workflow.id, onReopen]
+  );
+
   return (
     <div className="p-6 space-y-4 max-w-2xl mx-auto">
       <div className="flex items-center gap-3">
-        <div className="w-10 h-10 rounded-full bg-emerald-600/20 flex items-center justify-center shrink-0">
-          <span className="text-lg">✓</span>
+        <div
+          className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${
+            taskFailed ? "bg-red-600/20" : "bg-emerald-600/20"
+          }`}
+        >
+          <span className="text-lg">{taskFailed ? "!" : "✓"}</span>
         </div>
         <div>
-          <h3 className="text-base font-semibold text-zinc-200">Implementation Complete</h3>
-          <p className="text-xs text-zinc-500">The AI agent has finished working on this story</p>
+          <h3 className="text-base font-semibold text-zinc-200">
+            {taskFailed ? "Implementation Failed" : "Implementation Complete"}
+          </h3>
+          <p className="text-xs text-zinc-500">
+            {taskFailed
+              ? "The AI agent encountered an error while working on this story"
+              : "The AI agent has finished working on this story"}
+          </p>
         </div>
       </div>
 
@@ -743,15 +806,36 @@ function DoneView({ workflow, onClose }: { workflow: WorkflowState; onClose: () 
       )}
 
       {workflow.taskId && (
-        <TaskStatusPanel taskId={workflow.taskId} />
+        <TaskStatusPanel
+          taskId={workflow.taskId}
+          onStatusChange={handleStatusChange}
+          onRestart={handleRestart}
+        />
+      )}
+
+      {restarting && (
+        <p className="text-xs text-indigo-400 animate-pulse">Restarting task...</p>
       )}
 
       <div className="flex gap-3 pt-2">
+        {taskFailed && workflow.taskId && (
+          <button
+            onClick={() => handleRestart(workflow.taskId!)}
+            disabled={restarting}
+            className="px-4 py-2 text-sm rounded-md bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 transition-colors font-medium"
+          >
+            {restarting ? "Restarting..." : "Retry Implementation"}
+          </button>
+        )}
         <button
           onClick={onClose}
-          className="px-4 py-2 text-sm rounded-md bg-indigo-600 hover:bg-indigo-500"
+          className={`px-4 py-2 text-sm rounded-md ${
+            taskFailed
+              ? "border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800"
+              : "bg-indigo-600 hover:bg-indigo-500"
+          } transition-colors`}
         >
-          Done
+          {taskFailed ? "Close" : "Done"}
         </button>
       </div>
     </div>

--- a/src/components/project/RequirementsView.tsx
+++ b/src/components/project/RequirementsView.tsx
@@ -48,14 +48,25 @@ const PHASES: { key: Phase; label: string }[] = [
 ];
 
 
-const PHASE_CONFIG: Record<Phase, { label: string; color: string; icon: string }> = {
+const PHASE_CONFIG: Record<Phase | "failed", { label: string; color: string; icon: string }> = {
   gathering: { label: "Gathering", color: "bg-blue-600/20 text-blue-400 border-blue-600/30", icon: "?" },
   planning: { label: "Planning", color: "bg-purple-600/20 text-purple-400 border-purple-600/30", icon: "~" },
   review: { label: "Review", color: "bg-amber-600/20 text-amber-400 border-amber-600/30", icon: "!" },
   approved: { label: "Approved", color: "bg-emerald-600/20 text-emerald-400 border-emerald-600/30", icon: "+" },
   implementing: { label: "Implementing", color: "bg-orange-600/20 text-orange-400 border-orange-600/30", icon: "*" },
   done: { label: "Done", color: "bg-zinc-700/50 text-zinc-300 border-zinc-600/30", icon: "v" },
+  failed: { label: "Failed", color: "bg-red-600/20 text-red-400 border-red-600/30", icon: "x" },
 };
+
+function getEffectivePhase(w: WorkflowState, taskStatuses: Record<string, TaskInfo>): Phase | "failed" {
+  if (w.phase === "done" && w.taskId) {
+    const task = taskStatuses[w.taskId];
+    if (!task || task.status === "failed" || task.status === "cancelled") {
+      return "failed";
+    }
+  }
+  return w.phase;
+}
 
 interface Props {
   onSelectWorkflow: (id: string) => void;
@@ -67,6 +78,7 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
   const [loading, setLoading] = useState(true);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [taskStatuses, setTaskStatuses] = useState<Record<string, TaskInfo>>({});
+  const [restartingId, setRestartingId] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchWorkflows = () => {
@@ -116,6 +128,37 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
     });
   };
 
+  const refreshWorkflows = () => {
+    fetch("/api/project/workflow")
+      .then((r) => r.json())
+      .then((d) => setWorkflows(d.workflows ?? []));
+  };
+
+  const handleRestart = async (w: WorkflowState) => {
+    if (!w.taskId || restartingId) return;
+    setRestartingId(w.id);
+    try {
+      // 1. Restart the failed task
+      const restartRes = await fetch(`/api/tasks/${w.taskId}/restart`, { method: "POST" });
+      const restartData = await restartRes.json();
+      if (!restartData.taskId) return;
+
+      // 2. Reopen the workflow with the new task ID
+      await fetch(`/api/project/workflow/${w.id}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "reopen", taskId: restartData.taskId }),
+      });
+
+      // 3. Refresh the view
+      refreshWorkflows();
+    } catch (err) {
+      console.error("Failed to restart task:", err);
+    } finally {
+      setRestartingId(null);
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full text-zinc-500 animate-pulse">
@@ -153,12 +196,16 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
           <div className="space-y-2">
             {workflows.map((w) => {
               const isExpanded = expandedIds.has(w.id);
-              const cfg = PHASE_CONFIG[w.phase];
+              const effectivePhase = getEffectivePhase(w, taskStatuses);
+              const failed = effectivePhase === "failed";
+              const cfg = PHASE_CONFIG[effectivePhase];
               const title =
                 w.generatedStory?.title ??
                 w.messages.find((m) => m.role === "user")?.content.slice(0, 80) ??
                 "Untitled requirement";
-              const currentPhaseIdx = PHASES.findIndex((p) => p.key === w.phase);
+              // For failed tasks, show implementing as the current phase (not done)
+              const displayPhase = failed ? "implementing" : w.phase;
+              const currentPhaseIdx = PHASES.findIndex((p) => p.key === displayPhase);
 
               return (
                 <div key={w.id} className="rounded-lg border border-zinc-800 overflow-hidden">
@@ -198,6 +245,7 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
                         {PHASES.map((phase, i) => {
                           const isDone = i < currentPhaseIdx;
                           const isCurrent = i === currentPhaseIdx;
+                          const isFailed = failed && isCurrent && phase.key === "implementing";
                           const phaseCfg = PHASE_CONFIG[phase.key];
 
                           // Build sub-step detail
@@ -221,15 +269,17 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
                               {/* Connector line + status dot */}
                               <div className="relative flex flex-col items-center w-4 shrink-0">
                                 {i > 0 && (
-                                  <div className={`absolute -top-3 w-px h-3 ${isDone || isCurrent ? "bg-emerald-600/40" : "bg-zinc-700/50"}`} />
+                                  <div className={`absolute -top-3 w-px h-3 ${isDone || isCurrent ? (isFailed ? "bg-red-600/40" : "bg-emerald-600/40") : "bg-zinc-700/50"}`} />
                                 )}
                                 <div
                                   className={`w-2.5 h-2.5 rounded-full border ${
-                                    isDone
-                                      ? "bg-emerald-600 border-emerald-500"
-                                      : isCurrent
-                                        ? "bg-indigo-600 border-indigo-500 ring-2 ring-indigo-600/30"
-                                        : "bg-zinc-800 border-zinc-600"
+                                    isFailed
+                                      ? "bg-red-600 border-red-500 ring-2 ring-red-600/30"
+                                      : isDone
+                                        ? "bg-emerald-600 border-emerald-500"
+                                        : isCurrent
+                                          ? "bg-indigo-600 border-indigo-500 ring-2 ring-indigo-600/30"
+                                          : "bg-zinc-800 border-zinc-600"
                                   }`}
                                 />
                                 {i < PHASES.length - 1 && (
@@ -240,18 +290,25 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
                               {/* Label */}
                               <span
                                 className={`text-xs ${
-                                  isDone
-                                    ? "text-zinc-500 line-through"
-                                    : isCurrent
-                                      ? "text-zinc-200 font-medium"
-                                      : "text-zinc-600"
+                                  isFailed
+                                    ? "text-red-400 font-medium"
+                                    : isDone
+                                      ? "text-zinc-500 line-through"
+                                      : isCurrent
+                                        ? "text-zinc-200 font-medium"
+                                        : "text-zinc-600"
                                 }`}
                               >
                                 {phase.label}
                               </span>
 
                               {/* Status badge for current */}
-                              {isCurrent && (
+                              {isFailed && (
+                                <span className="text-[10px] px-1.5 py-0.5 rounded border bg-red-600/20 text-red-400 border-red-600/30">
+                                  Failed
+                                </span>
+                              )}
+                              {isCurrent && !isFailed && (
                                 <span className={`text-[10px] px-1.5 py-0.5 rounded border ${phaseCfg.color}`}>
                                   In Progress
                                 </span>
@@ -284,12 +341,23 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
                             </a>
                           )}
                         </div>
-                        <button
-                          onClick={() => onSelectWorkflow(w.id)}
-                          className="text-[10px] px-2 py-1 rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
-                        >
-                          Open Workflow →
-                        </button>
+                        <div className="flex items-center gap-2">
+                          {failed && w.taskId && (
+                            <button
+                              onClick={() => handleRestart(w)}
+                              disabled={restartingId === w.id}
+                              className="text-[10px] px-2 py-1 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors disabled:opacity-50"
+                            >
+                              {restartingId === w.id ? "Restarting..." : "Restart Task"}
+                            </button>
+                          )}
+                          <button
+                            onClick={() => onSelectWorkflow(w.id)}
+                            className="text-[10px] px-2 py-1 rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                          >
+                            Open Workflow →
+                          </button>
+                        </div>
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- When a workflow is "done" but its linked task failed/cancelled, the requirements tree now shows a red "Failed" badge (instead of green "Done") with a red dot on the implementing phase step
- Added "Restart Task" button in the requirements tree footer and "Retry Implementation" button in the workflow DoneView for failed tasks
- Added "reopen" action to the workflow chat API that transitions a done workflow back to implementing with a new task ID

## Test plan
- [ ] Create a workflow, start implementation, then mark the task as failed
- [ ] Verify the requirements list shows "Failed" badge in red instead of "Done"
- [ ] Verify the tree view shows implementing step with red dot and "Failed" badge
- [ ] Click "Restart Task" from requirements view -- verify new task starts and workflow returns to implementing
- [ ] Open workflow detail when task is failed -- verify "Implementation Failed" heading with retry button
- [ ] Click "Retry Implementation" from workflow detail -- verify workflow transitions back to implementing
- [ ] Verify successful completions still show green "Done" normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)