### PR TITLE
Centralize port config to 3456

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ bun install
 bun dev
 ```
 
-Then open [http://localhost:3000](http://localhost:3000).
+Then open [http://localhost:3456](http://localhost:3456).
 
 ## Install (Production CLI)
 
@@ -40,7 +40,7 @@ On first launch, FACE detects installed AI agents (Claude Code, Codex) and confi
 | Command | Description |
 |---------|-------------|
 | `bun install` | Install dependencies |
-| `bun dev` | Start dev server ([http://localhost:3000](http://localhost:3000)) |
+| `bun dev` | Start dev server ([http://localhost:3456](http://localhost:3456)) |
 | `bun run build` | Production build |
 | `bun start` | Start production server |
 | `bun run lint` | Run linter |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3456",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/src/lib/agents/setup.ts
+++ b/src/lib/agents/setup.ts
@@ -3,6 +3,7 @@ import path from "path";
 import os from "os";
 import { readConfig, writeConfig } from "../tasks/file-manager";
 import { detectAllAgents } from "./detect";
+import { FACE_BASE_URL } from "../constants";
 
 const CLAUDE_SETTINGS_PATH = path.join(
   os.homedir(),
@@ -10,7 +11,7 @@ const CLAUDE_SETTINGS_PATH = path.join(
   "settings.json"
 );
 
-const FACE_HOOK_URL = "http://localhost:3456/api/hooks/task-update";
+const FACE_HOOK_URL = `${FACE_BASE_URL}/api/hooks/task-update`;
 
 // We tag our hooks with this command prefix so we can find/remove them later
 const FACE_HOOK_TAG = "# face-hook";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Default port for the FACE dashboard.
+ *
+ * Used by the dev server, hook installation, and any code that generates
+ * URLs pointing back to the dashboard. The `face` CLI launcher and
+ * `install.sh` also default to this value (via the PORT env var).
+ */
+export const FACE_PORT = 3456;
+
+/** Base URL for the FACE dashboard (no trailing slash). */
+export const FACE_BASE_URL = `http://localhost:${FACE_PORT}`;

--- a/src/lib/tasks/github-notify.ts
+++ b/src/lib/tasks/github-notify.ts
@@ -1,4 +1,5 @@
 import { getActiveProvider } from "@/lib/project/manager";
+import { FACE_BASE_URL } from "@/lib/constants";
 import type { FaceTask } from "./types";
 
 /**
@@ -70,7 +71,7 @@ function buildCommentBody(task: FaceTask): string {
   }
 
   lines.push("");
-  lines.push(`[View full task details in FACE](http://localhost:3000/project?task=${task.id})`);
+  lines.push(`[View full task details in FACE](${FACE_BASE_URL}/project?task=${task.id})`);
 
   if (task.summary) {
     lines.push("");


### PR DESCRIPTION
## Summary
- Add `FACE_PORT` and `FACE_BASE_URL` constants in `src/lib/constants.ts` as the single source of truth for the dashboard port
- Update `package.json` dev script to `next dev --port 3456` (was defaulting to 3000)
- Update `src/lib/agents/setup.ts` and `src/lib/tasks/github-notify.ts` to import from the shared constants instead of hardcoding URLs
- Fix `README.md` port references from 3000 to 3456

## Test plan
- [ ] Run `bun dev` and confirm it starts on port 3456
- [ ] Verify Claude Code hook setup writes URLs pointing to localhost:3456
- [ ] Check that GitHub notification comments link to localhost:3456

🤖 Generated with [Claude Code](https://claude.com/claude-code)