### PR TITLE
Scope sidebar links per role with client-side content switching

### DIFF
--- a/src/app/[role]/page.tsx
+++ b/src/app/[role]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { getRoleDefinition, getRoleSlugs } from "@/lib/roles/registry";
 import { RoleDashboard } from "@/components/widgets/RoleDashboard";
@@ -25,5 +26,9 @@ export default async function RolePage({ params }: RolePageProps) {
     notFound();
   }
 
-  return <RoleDashboard role={roleDef} />;
+  return (
+    <Suspense>
+      <RoleDashboard role={roleDef} />
+    </Suspense>
+  );
 }

--- a/src/components/widgets/RoleDashboard.tsx
+++ b/src/components/widgets/RoleDashboard.tsx
@@ -1,111 +1,137 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import type { RoleDefinition } from "@/lib/roles/types";
+import type { RoleDefinition, SidebarLink } from "@/lib/roles/types";
 import { WidgetRenderer } from "./WidgetRenderer";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 interface RoleDashboardProps {
   role: RoleDefinition;
 }
 
-interface RoleSummary {
-  slug: string;
-  label: string;
-  routePath: string;
-  iconPath: string;
-  readOnly: boolean;
-}
-
 /**
  * Assembles a role-specific dashboard from the role definition's widget list.
- * Includes a sidebar for navigation and role switching (desktop) and a
- * hamburger-driven drawer on mobile.
+ * The sidebar shows only links relevant to the current role. Clicking a link
+ * swaps the main content area via client-side state without a full route change.
  */
 export function RoleDashboard({ role }: RoleDashboardProps) {
-  const pathname = usePathname();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [roles, setRoles] = useState<RoleSummary[]>([]);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const viewParam = searchParams.get("view");
 
+  // Resolve active view: match query param to a sidebar link key, fallback to null (overview)
+  const resolveView = useCallback(
+    (param: string | null): string | null => {
+      if (!param) return null;
+      return role.sidebarLinks.find((l) => l.key === param) ? param : null;
+    },
+    [role.sidebarLinks],
+  );
+
+  const [activeView, setActiveView] = useState<string | null>(() => resolveView(viewParam));
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  // Sync state when query param changes externally (e.g. back/forward)
   useEffect(() => {
-    fetch("/api/roles")
-      .then((r) => r.json())
-      .then((data) => {
-        if (data.roles) setRoles(data.roles);
-      })
-      .catch(() => {});
-  }, []);
+    setActiveView(resolveView(viewParam));
+  }, [viewParam, resolveView]);
 
   const closeMobileMenu = useCallback(() => setMobileMenuOpen(false), []);
 
-  // Close mobile menu on route change
-  useEffect(() => {
-    closeMobileMenu();
-  }, [pathname, closeMobileMenu]);
+  const handleViewChange = useCallback(
+    (key: string | null) => {
+      setActiveView(key);
+      closeMobileMenu();
+      const url = key ? `${role.routePath}?view=${key}` : role.routePath;
+      router.replace(url, { scroll: false });
+    },
+    [role.routePath, router, closeMobileMenu],
+  );
 
   // Prevent body scroll when mobile menu open
   useEffect(() => {
     if (mobileMenuOpen) {
       document.body.style.overflow = "hidden";
-      return () => { document.body.style.overflow = ""; };
+      return () => {
+        document.body.style.overflow = "";
+      };
     }
   }, [mobileMenuOpen]);
+
+  // Determine which widgets to render
+  const activeLink = activeView
+    ? role.sidebarLinks.find((l) => l.key === activeView)
+    : null;
+  const widgetsToRender = activeLink ? activeLink.widgets : role.widgets;
 
   return (
     <div className="flex h-screen">
       {/* Desktop sidebar */}
       <aside className="hidden md:flex w-56 flex-col border-r border-zinc-800 bg-zinc-900">
         <div className="flex items-center justify-between border-b border-zinc-800 px-3 py-3">
-          <Link href="/" className="text-sm font-semibold text-zinc-100 hover:text-white transition-colors">
+          <Link
+            href="/"
+            className="text-sm font-semibold text-zinc-100 hover:text-white transition-colors"
+          >
             FACE
           </Link>
         </div>
-        <div className="border-b border-zinc-800 p-3">
-          <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-zinc-600">Roles</p>
-          <div className="space-y-0.5">
-            {roles.map((r) => (
-              <Link
-                key={r.slug}
-                href={r.routePath}
-                className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
-                  pathname === r.routePath
-                    ? "bg-zinc-800 text-zinc-100"
-                    : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200"
-                }`}
-              >
-                <svg className={`h-3.5 w-3.5 flex-shrink-0 ${pathname === r.routePath ? "text-blue-400" : "text-zinc-500"}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                  <path strokeLinecap="round" strokeLinejoin="round" d={r.iconPath} />
-                </svg>
-                <span className="truncate">{r.label}</span>
-                {pathname === r.routePath && <span className="ml-auto h-1.5 w-1.5 rounded-full bg-blue-400" />}
-              </Link>
+
+        <nav className="flex-1 overflow-y-auto p-3">
+          <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-zinc-600">
+            {role.label}
+          </p>
+          {/* Overview (all widgets) */}
+          <button
+            onClick={() => handleViewChange(null)}
+            className={`w-full text-left flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+              activeView === null
+                ? "bg-zinc-800 text-zinc-100"
+                : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200"
+            }`}
+          >
+            <span className="text-base">⊞</span>
+            <span className="truncate">Overview</span>
+            {activeView === null && (
+              <span className="ml-auto h-1.5 w-1.5 rounded-full bg-blue-400" />
+            )}
+          </button>
+
+          <div className="mt-1 space-y-0.5">
+            {role.sidebarLinks.map((link) => (
+              <SidebarButton
+                key={link.key}
+                link={link}
+                isActive={activeView === link.key}
+                onClick={() => handleViewChange(link.key)}
+              />
             ))}
           </div>
-        </div>
-        <nav className="flex-1 overflow-y-auto p-3">
-          {role.permissions.canViewProject && (
-            <div className="mb-3">
-              <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-zinc-600">Project</p>
-              <Link href="/project" className="block rounded-md px-2 py-1.5 text-sm text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200">Board</Link>
-              <Link href="/project?view=milestones" className="block rounded-md px-2 py-1.5 text-sm text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200">Milestones</Link>
-            </div>
-          )}
-          {role.permissions.canConfigure && (
-            <div className="mb-3">
-              <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-zinc-600">Settings</p>
-              <Link href="/project?view=settings" className="block rounded-md px-2 py-1.5 text-sm text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200">Configuration</Link>
-            </div>
-          )}
         </nav>
+
         <div className="border-t border-zinc-800 p-3">
           <div className="flex items-center gap-2">
-            <svg className="h-4 w-4 text-blue-400 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <path strokeLinecap="round" strokeLinejoin="round" d={role.iconPath} />
+            <svg
+              className="h-4 w-4 text-blue-400 flex-shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d={role.iconPath}
+              />
             </svg>
             <div className="min-w-0">
-              <p className="text-xs font-medium text-zinc-200 truncate">{role.label}</p>
-              {role.permissions.readOnly && <p className="text-[10px] text-zinc-500">Read-only</p>}
+              <p className="text-xs font-medium text-zinc-200 truncate">
+                {role.label}
+              </p>
+              {role.permissions.readOnly && (
+                <p className="text-[10px] text-zinc-500">Read-only</p>
+              )}
             </div>
           </div>
         </div>
@@ -114,37 +140,66 @@ export function RoleDashboard({ role }: RoleDashboardProps) {
       {/* Mobile sidebar overlay */}
       {mobileMenuOpen && (
         <div className="fixed inset-0 z-50 md:hidden">
-          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={closeMobileMenu} />
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={closeMobileMenu}
+          />
           <aside className="absolute inset-y-0 left-0 w-72 bg-zinc-900 border-r border-zinc-800 flex flex-col animate-in slide-in-from-left duration-200">
             <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
-              <Link href="/" className="text-sm font-semibold text-zinc-100">FACE</Link>
-              <button onClick={closeMobileMenu} className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300" aria-label="Close menu">
-                <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              <Link href="/" className="text-sm font-semibold text-zinc-100">
+                FACE
+              </Link>
+              <button
+                onClick={closeMobileMenu}
+                className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+                aria-label="Close menu"
+              >
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
                 </svg>
               </button>
             </div>
-            <div className="border-b border-zinc-800 p-4">
-              <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-zinc-600">Switch Role</p>
-              <div className="space-y-1">
-                {roles.map((r) => (
-                  <Link key={r.slug} href={r.routePath} className={`flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors ${pathname === r.routePath ? "bg-zinc-800 text-zinc-100" : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200"}`}>
-                    <svg className={`h-4 w-4 flex-shrink-0 ${pathname === r.routePath ? "text-blue-400" : "text-zinc-500"}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                      <path strokeLinecap="round" strokeLinejoin="round" d={r.iconPath} />
-                    </svg>
-                    <span>{r.label}</span>
-                    {pathname === r.routePath && <span className="ml-auto h-1.5 w-1.5 rounded-full bg-blue-400" />}
-                  </Link>
+
+            <nav className="flex-1 overflow-y-auto p-4">
+              <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-zinc-600">
+                {role.label}
+              </p>
+              <button
+                onClick={() => handleViewChange(null)}
+                className={`w-full text-left flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors ${
+                  activeView === null
+                    ? "bg-zinc-800 text-zinc-100"
+                    : "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200"
+                }`}
+              >
+                <span className="text-base">⊞</span>
+                <span>Overview</span>
+                {activeView === null && (
+                  <span className="ml-auto h-1.5 w-1.5 rounded-full bg-blue-400" />
+                )}
+              </button>
+
+              <div className="mt-1 space-y-1">
+                {role.sidebarLinks.map((link) => (
+                  <SidebarButton
+                    key={link.key}
+                    link={link}
+                    isActive={activeView === link.key}
+                    onClick={() => handleViewChange(link.key)}
+                    mobile
+                  />
                 ))}
               </div>
-            </div>
-            <nav className="flex-1 overflow-y-auto p-4">
-              {role.permissions.canViewProject && (
-                <Link href="/project" className="block rounded-md px-3 py-2 text-sm text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200">Project Board</Link>
-              )}
-              {role.permissions.canConfigure && (
-                <Link href="/project?view=settings" className="block rounded-md px-3 py-2 text-sm text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200">Settings</Link>
-              )}
             </nav>
           </aside>
         </div>
@@ -154,20 +209,56 @@ export function RoleDashboard({ role }: RoleDashboardProps) {
       <div className="flex flex-1 flex-col min-w-0">
         {/* Header */}
         <header className="flex items-center gap-3 border-b border-zinc-800 px-4 py-3 md:px-6">
-          <button onClick={() => setMobileMenuOpen(true)} className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 md:hidden" aria-label="Open menu">
-            <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+          <button
+            onClick={() => setMobileMenuOpen(true)}
+            className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 md:hidden"
+            aria-label="Open menu"
+          >
+            <svg
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+              />
             </svg>
           </button>
-          <svg className="h-5 w-5 text-blue-400 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-            <path strokeLinecap="round" strokeLinejoin="round" d={role.iconPath} />
+          <svg
+            className="h-5 w-5 text-blue-400 flex-shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d={role.iconPath}
+            />
           </svg>
           <div className="min-w-0">
-            <h1 className="text-sm font-semibold text-zinc-100 truncate">{role.label}</h1>
-            <p className="text-xs text-zinc-500 truncate hidden sm:block">{role.description}</p>
+            <h1 className="text-sm font-semibold text-zinc-100 truncate">
+              {role.label}
+              {activeLink && (
+                <span className="font-normal text-zinc-400">
+                  {" "}
+                  / {activeLink.label}
+                </span>
+              )}
+            </h1>
+            <p className="text-xs text-zinc-500 truncate hidden sm:block">
+              {role.description}
+            </p>
           </div>
           {role.permissions.readOnly && (
-            <span className="ml-auto rounded-full border border-zinc-700 bg-zinc-800/50 px-2 py-0.5 text-xs text-zinc-400 flex-shrink-0">Read-only</span>
+            <span className="ml-auto rounded-full border border-zinc-700 bg-zinc-800/50 px-2 py-0.5 text-xs text-zinc-400 flex-shrink-0">
+              Read-only
+            </span>
           )}
         </header>
 
@@ -182,9 +273,9 @@ export function RoleDashboard({ role }: RoleDashboardProps) {
         {/* Widget grid */}
         <main className="flex-1 overflow-auto p-4 md:p-6">
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {role.widgets.map((widget, index) => (
+            {widgetsToRender.map((widget, index) => (
               <WidgetRenderer
-                key={`${widget.type}-${index}`}
+                key={`${activeView ?? "overview"}-${widget.type}-${index}`}
                 config={widget}
                 promptTemplates={role.aiBehavior.promptTemplates}
               />
@@ -193,5 +284,34 @@ export function RoleDashboard({ role }: RoleDashboardProps) {
         </main>
       </div>
     </div>
+  );
+}
+
+/** Sidebar navigation button for a single link. */
+function SidebarButton({
+  link,
+  isActive,
+  onClick,
+  mobile,
+}: {
+  link: SidebarLink;
+  isActive: boolean;
+  onClick: () => void;
+  mobile?: boolean;
+}) {
+  const base = mobile
+    ? "w-full text-left flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors"
+    : "w-full text-left flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors";
+  const active = "bg-zinc-800 text-zinc-100";
+  const inactive = "text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200";
+
+  return (
+    <button onClick={onClick} className={`${base} ${isActive ? active : inactive}`}>
+      <span className="text-base">{link.icon}</span>
+      <span className="truncate">{link.label}</span>
+      {isActive && (
+        <span className="ml-auto h-1.5 w-1.5 rounded-full bg-blue-400" />
+      )}
+    </button>
   );
 }

--- a/src/lib/roles/registry.ts
+++ b/src/lib/roles/registry.ts
@@ -48,6 +48,14 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
       { type: "issue-board", title: "Board", size: "large" },
       { type: "agent-status", title: "Agent Status", size: "small" },
     ],
+    sidebarLinks: [
+      { key: "requirements", label: "Requirements", icon: "◉", widgets: [{ type: "requirements-list", title: "Requirements", size: "full" }] },
+      { key: "new-requirement", label: "New Requirement", icon: "✦", widgets: [{ type: "task-submit", title: "New Requirement", size: "full" }] },
+      { key: "issues", label: "Issues", icon: "☰", widgets: [{ type: "issue-list", title: "Issues", size: "full" }] },
+      { key: "tasks", label: "Tasks", icon: "▤", widgets: [{ type: "task-list", title: "Tasks", size: "full" }] },
+      { key: "board", label: "Board", icon: "▦", widgets: [{ type: "issue-board", title: "Board", size: "full" }] },
+      { key: "milestones", label: "Milestones", icon: "◎", widgets: [{ type: "milestone-summary", title: "Milestones", size: "full" }] },
+    ],
   },
   {
     slug: "pm",
@@ -86,6 +94,13 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
       { type: "requirements-list", title: "Requirements", size: "medium" },
       { type: "task-list", title: "Recent Tasks", size: "large" },
     ],
+    sidebarLinks: [
+      { key: "requirements", label: "Requirements", icon: "◉", widgets: [{ type: "requirements-list", title: "Requirements", size: "full" }] },
+      { key: "new-requirement", label: "New Requirement", icon: "✦", widgets: [{ type: "task-submit", title: "New Requirement", size: "full" }] },
+      { key: "milestones", label: "Milestones", icon: "◎", widgets: [{ type: "milestone-summary", title: "Milestones", size: "full" }] },
+      { key: "roadmap", label: "Roadmap", icon: "▸", widgets: [{ type: "task-list", title: "Roadmap", size: "full" }] },
+      { key: "board", label: "Board", icon: "▦", widgets: [{ type: "issue-board", title: "Board", size: "full" }] },
+    ],
   },
   {
     slug: "test",
@@ -123,6 +138,13 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
       { type: "task-list", title: "Test Tasks", size: "medium" },
       { type: "triage-summary", title: "Triage", size: "medium" },
     ],
+    sidebarLinks: [
+      { key: "issues", label: "Issues", icon: "☰", widgets: [{ type: "issue-list", title: "Issues", size: "full" }] },
+      { key: "bugs", label: "Bug Tracker", icon: "⚑", widgets: [{ type: "issue-list", title: "Bug Tracker", size: "full", props: { filterLabel: "bug" } }] },
+      { key: "triage", label: "Triage", icon: "◆", widgets: [{ type: "triage-summary", title: "Triage", size: "full" }] },
+      { key: "tasks", label: "Test Tasks", icon: "▤", widgets: [{ type: "task-list", title: "Test Tasks", size: "full" }] },
+      { key: "board", label: "Board", icon: "▦", widgets: [{ type: "issue-board", title: "Board", size: "full" }] },
+    ],
   },
   {
     slug: "design",
@@ -155,6 +177,11 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
       { type: "task-list", title: "Design Tasks", size: "large" },
       { type: "issue-list", title: "Design Issues", size: "medium", props: { filterLabel: "design" } },
     ],
+    sidebarLinks: [
+      { key: "issues", label: "Design Issues", icon: "☰", widgets: [{ type: "issue-list", title: "Design Issues", size: "full", props: { filterLabel: "design" } }] },
+      { key: "tasks", label: "Design Tasks", icon: "▤", widgets: [{ type: "task-list", title: "Design Tasks", size: "full" }] },
+      { key: "board", label: "Board", icon: "▦", widgets: [{ type: "issue-board", title: "Board", size: "full" }] },
+    ],
   },
   {
     slug: "hr",
@@ -185,6 +212,9 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
     widgets: [
       { type: "task-submit", title: "Ask AI", size: "full" },
       { type: "task-list", title: "HR Tasks", size: "large" },
+    ],
+    sidebarLinks: [
+      { key: "tasks", label: "HR Tasks", icon: "▤", widgets: [{ type: "task-list", title: "HR Tasks", size: "full" }] },
     ],
   },
   {
@@ -217,6 +247,9 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
       { type: "task-submit", title: "Ask AI", size: "full" },
       { type: "task-list", title: "Finance Tasks", size: "large" },
     ],
+    sidebarLinks: [
+      { key: "tasks", label: "Finance Tasks", icon: "▤", widgets: [{ type: "task-list", title: "Finance Tasks", size: "full" }] },
+    ],
   },
   {
     slug: "sales",
@@ -248,6 +281,9 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
       { type: "task-submit", title: "Ask AI", size: "full" },
       { type: "task-list", title: "Sales Tasks", size: "large" },
     ],
+    sidebarLinks: [
+      { key: "tasks", label: "Sales Tasks", icon: "▤", widgets: [{ type: "task-list", title: "Sales Tasks", size: "full" }] },
+    ],
   },
   {
     slug: "stakeholder",
@@ -275,6 +311,11 @@ const BUILT_IN_ROLES: RoleDefinition[] = [
       { type: "milestone-summary", title: "Milestone Progress", size: "full" },
       { type: "issue-board", title: "Project Board", size: "large", props: { readOnly: true } },
       { type: "task-list", title: "Recent Activity", size: "medium", props: { readOnly: true } },
+    ],
+    sidebarLinks: [
+      { key: "milestones", label: "Milestone Progress", icon: "◎", widgets: [{ type: "milestone-summary", title: "Milestone Progress", size: "full" }] },
+      { key: "board", label: "Project Board", icon: "▦", widgets: [{ type: "issue-board", title: "Project Board", size: "full", props: { readOnly: true } }] },
+      { key: "activity", label: "Recent Activity", icon: "▤", widgets: [{ type: "task-list", title: "Recent Activity", size: "full", props: { readOnly: true } }] },
     ],
   },
 ];

--- a/src/lib/roles/types.ts
+++ b/src/lib/roles/types.ts
@@ -6,6 +6,19 @@
  * route and view from configuration, not hardcoded pages.
  */
 
+// ── Sidebar navigation ───────────────────────────────────────────
+
+export interface SidebarLink {
+  /** Unique view key used in query params (e.g. "board", "issues") */
+  key: string;
+  /** Display label */
+  label: string;
+  /** Text icon character */
+  icon: string;
+  /** Widgets rendered when this view is active */
+  widgets: WidgetConfig[];
+}
+
 // ── Widget types (composable dashboard building blocks) ───────────
 
 export type WidgetSize = "small" | "medium" | "large" | "full";
@@ -66,6 +79,8 @@ export interface RoleDefinition {
   aiBehavior: AIBehaviorProfile;
   /** Ordered list of widgets that compose this role's dashboard */
   widgets: WidgetConfig[];
+  /** Sidebar navigation links — each maps to a focused widget view */
+  sidebarLinks: SidebarLink[];
   /** Maps to a UserRole value for backward compat with adaptive system */
   userRole: string;
 }


### PR DESCRIPTION
## Summary
- Replaces the generic role-switching sidebar with role-scoped navigation links (e.g. Requirements, Issues, Board, Tasks)
- Each sidebar link swaps the main widget area via client-side state (`?view=` query param) instead of full route changes
- Adds `SidebarLink` type to role definitions with per-link widget configs
- All 8 roles now have curated sidebar links relevant to their responsibilities
- Wraps `RoleDashboard` in `Suspense` for `useSearchParams` compatibility

## Test plan
- [ ] Navigate to each role page — verify sidebar shows role-specific links
- [ ] Click sidebar links — main content swaps without full page reload
- [ ] Verify `?view=` query param updates in URL and works with back/forward
- [ ] Mobile hamburger menu shows same scoped links
- [ ] "Overview" shows all widgets for the role

🤖 Generated with [Claude Code](https://claude.com/claude-code)