### PR TITLE
Fix false stale-task warnings by adding heartbeat

### DIFF
--- a/src/components/project/TaskStatusPanel.tsx
+++ b/src/components/project/TaskStatusPanel.tsx
@@ -58,7 +58,7 @@ const CATEGORY_ICONS: Record<string, string> = {
 
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
-const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+const STALE_THRESHOLD_MS = 3 * 60 * 1000; // 3 minutes (heartbeat writes every 60s)
 
 function isTaskStale(task: TaskData): boolean {
   if (task.status !== "running") return false;
@@ -195,7 +195,7 @@ export function TaskStatusPanel({ taskId, onStatusChange, onRestart }: Props) {
         <div className="px-4 py-3 border-b border-zinc-800 bg-amber-950/30">
           <div className="flex items-center justify-between gap-3">
             <p className="text-xs text-amber-400">
-              Task may be stale — no updates received for over 5 minutes.
+              Task may be stale — no updates received for over 3 minutes.
             </p>
             <button
               onClick={handleMarkFailed}

--- a/src/lib/tasks/runner.ts
+++ b/src/lib/tasks/runner.ts
@@ -142,6 +142,18 @@ function spawnClaudeCode(task: FaceTask, binaryPath: string): void {
 
   runningTasks.set(task.id, child);
 
+  // Heartbeat: periodically update task.updatedAt so the UI doesn't
+  // think the task is stale during long operations with no tool_use events.
+  const HEARTBEAT_INTERVAL_MS = 60_000; // 60 seconds
+  const heartbeat = setInterval(() => {
+    task.updatedAt = new Date().toISOString();
+    writeTask(task);
+    eventBus.emit("task-file-changed", {
+      event: "change",
+      filename: `${task.id}.json`,
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+
   const MAX_OUTPUT = 2 * 1024 * 1024; // 2MB cap
   let stderr = "";
   let lineBuf = ""; // buffer for partial lines from stdout
@@ -234,6 +246,7 @@ function spawnClaudeCode(task: FaceTask, binaryPath: string): void {
   });
 
   child.on("close", (code) => {
+    clearInterval(heartbeat);
     runningTasks.delete(task.id);
 
     // Process any remaining partial line in the buffer
@@ -267,6 +280,7 @@ function spawnClaudeCode(task: FaceTask, binaryPath: string): void {
   });
 
   child.on("error", (err) => {
+    clearInterval(heartbeat);
     runningTasks.delete(task.id);
     task.status = "failed";
     task.result = err.message;


### PR DESCRIPTION
## Summary

- **Heartbeat in runner**: While the spawned Claude Code process is alive, a `setInterval` writes `task.updatedAt` every 60 seconds even when there are no streaming events. This prevents the UI from falsely detecting the task as stale during long AI operations (thinking, generating code, reading large files). The interval is cleared on process close or error.
- **Lower stale threshold**: Changed `STALE_THRESHOLD_MS` from 5 minutes to 3 minutes. With the heartbeat writing every 60s, 3 minutes without any update means 3 missed heartbeats, which genuinely indicates a stuck process.
- **Updated warning text** to reflect the new 3-minute threshold.

## Verification

- `ImplementingView` passes `onStatusChange` that only fires `onDone` on `"completed"` -- it does NOT set `taskFailed`, so the stale warning + "Mark as failed" button works correctly there.
- `DoneView` has its own independent `taskFailed` state, so the stale warning cannot appear in DoneView (tasks there are already completed/failed, and `isTaskStale` returns false for non-running tasks).

## Test plan

- [ ] Start an implementation task and verify no stale warning appears while the AI agent is actively working
- [ ] Verify stale warning appears after 3 minutes if the process is actually stuck
- [ ] Verify heartbeat interval is cleared when the process exits normally or with an error
- [ ] Verify DoneView does not show stale warnings