### PR TITLE
Sync requirements to project management tools (GitHub Projects / Linear) with role-based tagging and filtering

### DIFF
--- a/src/app/api/project/workflow/[workflowId]/chat/route.ts
+++ b/src/app/api/project/workflow/[workflowId]/chat/route.ts
@@ -134,10 +134,21 @@ export async function POST(
     }
 
     const story = workflow.generatedStory;
+
+    // Build labels: story labels + role tags
+    const labels = [...story.labels];
+    if (workflow.creatorRole) {
+      labels.push(`role:${workflow.creatorRole}`);
+    }
+    for (const role of workflow.assignedRoles) {
+      const tag = `role:${role}`;
+      if (!labels.includes(tag)) labels.push(tag);
+    }
+
     const issue = await provider.createIssue({
       title: story.title,
       body: story.body + `\n\n---\n_Priority: ${story.priority} | Effort: ${story.estimatedEffort} | Workflow: ${workflow.id}_`,
-      labels: story.labels,
+      labels,
     });
 
     workflow.issueId = issue.id;
@@ -231,6 +242,8 @@ export async function POST(
 
     const result = await submitTask("claude-code", prompt, {
       title: `Implement: ${workflow.generatedStory.title}`,
+      creatorRole: workflow.creatorRole ?? undefined,
+      assignedRoles: workflow.assignedRoles.length > 0 ? workflow.assignedRoles : undefined,
     });
 
     if (result.error) {
@@ -318,6 +331,21 @@ export async function POST(
       }
     }
 
+    return NextResponse.json({ workflow });
+  }
+
+  // ── Update assigned roles ──────────────────────────────────────
+  if (body.action === "update_roles") {
+    if (Array.isArray(body.assignedRoles)) {
+      workflow.assignedRoles = body.assignedRoles.filter(
+        (r: unknown) => typeof r === "string"
+      );
+    }
+    if (typeof body.creatorRole === "string") {
+      workflow.creatorRole = body.creatorRole;
+    }
+    workflow.updatedAt = new Date().toISOString();
+    saveWorkflow(workflow);
     return NextResponse.json({ workflow });
   }
 

--- a/src/app/api/project/workflow/route.ts
+++ b/src/app/api/project/workflow/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createWorkflow, listWorkflows } from "@/lib/project/workflow";
 
 export async function GET() {
@@ -6,7 +6,20 @@ export async function GET() {
   return NextResponse.json({ workflows });
 }
 
-export async function POST() {
-  const workflow = createWorkflow();
+export async function POST(request: NextRequest) {
+  let creatorRole: string | undefined;
+  let assignedRoles: string[] | undefined;
+
+  try {
+    const body = await request.json();
+    if (typeof body.creatorRole === "string") creatorRole = body.creatorRole;
+    if (Array.isArray(body.assignedRoles)) {
+      assignedRoles = body.assignedRoles.filter((r: unknown) => typeof r === "string");
+    }
+  } catch {
+    // No body or invalid JSON — proceed with defaults
+  }
+
+  const workflow = createWorkflow({ creatorRole, assignedRoles });
   return NextResponse.json({ workflow });
 }

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -9,6 +9,7 @@ export async function GET() {
       label: r.label,
       description: r.description,
       routePath: r.routePath,
+      userRole: r.userRole,
       readOnly: r.permissions.readOnly,
     })),
   });

--- a/src/app/api/tasks/submit/route.ts
+++ b/src/app/api/tasks/submit/route.ts
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { agentId, prompt, title, workingDirectory, linkedIssue } = body;
+  const { agentId, prompt, title, workingDirectory, linkedIssue, creatorRole, assignedRoles } = body;
 
   if (typeof agentId !== "string" || !KNOWN_AGENTS.has(agentId)) {
     return NextResponse.json(
@@ -71,10 +71,17 @@ export async function POST(request: NextRequest) {
     issueNumber = parsed;
   }
 
+  const safeCreatorRole = typeof creatorRole === "string" ? creatorRole : undefined;
+  const safeAssignedRoles = Array.isArray(assignedRoles)
+    ? assignedRoles.filter((r: unknown) => typeof r === "string")
+    : undefined;
+
   const result = await submitTask(agentId, prompt.trim(), {
     title: safeTitle,
     workingDirectory: cwd,
     linkedIssue: issueNumber,
+    creatorRole: safeCreatorRole,
+    assignedRoles: safeAssignedRoles,
   });
 
   if (result.error) {

--- a/src/components/project/RequirementWorkflow.tsx
+++ b/src/components/project/RequirementWorkflow.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { TaskStatusPanel } from "./TaskStatusPanel";
+import { useRoleSlug } from "@/components/shared/useRoleSlug";
+import { RoleTagBadge } from "@/components/shared/RoleTagBadge";
 
 // ── Types (mirroring server) ───────────────────────────────────────
 
@@ -32,6 +34,8 @@ interface WorkflowState {
   pmApproval: ApprovalStatus;
   engApproval: ApprovalStatus;
   taskId: string | null;
+  creatorRole: string | null;
+  assignedRoles: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -95,6 +99,7 @@ export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
   const [error, setError] = useState<string | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const { currentSlug: userRoleSlug } = useRoleSlug();
 
   // Load existing workflow, or set up a local-only placeholder for new ones.
   // New workflows are only persisted on the first message (see sendMessage).
@@ -115,6 +120,8 @@ export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
         pmApproval: "pending",
         engApproval: "pending",
         taskId: null,
+        creatorRole: null,
+        assignedRoles: [],
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       });
@@ -172,7 +179,14 @@ export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
 
       // If this is a brand-new workflow (not yet persisted), create it first
       if (!wfId) {
-        const createRes = await fetch("/api/project/workflow", { method: "POST" });
+        const createRes = await fetch("/api/project/workflow", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            creatorRole: userRoleSlug ?? undefined,
+            assignedRoles: userRoleSlug ? [userRoleSlug] : [],
+          }),
+        });
         const createData = await createRes.json();
         if (!createData.workflow?.id) throw new Error("Failed to create workflow");
         wfId = createData.workflow.id;
@@ -255,6 +269,16 @@ export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
             onApprove={(role) => doAction("approve", { role })}
             onReject={(role) => doAction("reject", { role })}
             onCreateIssue={() => doAction("create_issue")}
+            onAssignedRolesChange={(roles) => {
+              setWorkflow((w) => w ? { ...w, assignedRoles: roles } : null);
+              if (workflow.id) {
+                fetch(`/api/project/workflow/${workflow.id}/chat`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ action: "update_roles", assignedRoles: roles }),
+                });
+              }
+            }}
             loading={loading}
           />
         )}
@@ -438,6 +462,7 @@ function StoryReview({
   onApprove,
   onReject,
   onCreateIssue,
+  onAssignedRolesChange,
   loading,
 }: {
   story: GeneratedStory;
@@ -445,6 +470,7 @@ function StoryReview({
   onApprove: (role: string) => void;
   onReject: (role: string) => void;
   onCreateIssue: () => void;
+  onAssignedRolesChange: (roles: string[]) => void;
   loading: boolean;
 }) {
   return (
@@ -507,6 +533,13 @@ function StoryReview({
           )}
         </div>
       </div>
+
+      {/* Role tags */}
+      <RoleTagSelector
+        creatorRole={workflow.creatorRole}
+        assignedRoles={workflow.assignedRoles}
+        onChange={onAssignedRolesChange}
+      />
 
       {/* Create issue button */}
       {!workflow.issueId && (
@@ -837,6 +870,57 @@ function DoneView({
         >
           {taskFailed ? "Close" : "Done"}
         </button>
+      </div>
+    </div>
+  );
+}
+
+function RoleTagSelector({
+  creatorRole,
+  assignedRoles,
+  onChange,
+}: {
+  creatorRole: string | null;
+  assignedRoles: string[];
+  onChange: (roles: string[]) => void;
+}) {
+  const { roles } = useRoleSlug();
+
+  const toggle = (slug: string) => {
+    if (assignedRoles.includes(slug)) {
+      onChange(assignedRoles.filter((r) => r !== slug));
+    } else {
+      onChange([...assignedRoles, slug]);
+    }
+  };
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-medium text-zinc-400">Role Tags</span>
+        {creatorRole && (
+          <span className="flex items-center gap-1 text-[10px] text-zinc-500">
+            Creator: <RoleTagBadge role={creatorRole} variant="creator" />
+          </span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {roles.map((r) => {
+          const active = assignedRoles.includes(r.slug);
+          return (
+            <button
+              key={r.slug}
+              onClick={() => toggle(r.slug)}
+              className={`text-[10px] px-2 py-1 rounded border transition-colors ${
+                active
+                  ? "bg-indigo-600/20 text-indigo-300 border-indigo-600/40"
+                  : "bg-zinc-800 text-zinc-500 border-zinc-700 hover:text-zinc-300 hover:border-zinc-600"
+              }`}
+            >
+              {r.slug}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/project/RequirementsView.tsx
+++ b/src/components/project/RequirementsView.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { RoleTagBadge } from "@/components/shared/RoleTagBadge";
+import { useRoleSlug } from "@/components/shared/useRoleSlug";
 
 interface ChatMessage {
   role: "user" | "assistant";
@@ -28,6 +30,8 @@ interface WorkflowState {
   pmApproval: string;
   engApproval: string;
   taskId: string | null;
+  creatorRole: string | null;
+  assignedRoles: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -79,6 +83,15 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [taskStatuses, setTaskStatuses] = useState<Record<string, TaskInfo>>({});
   const [restartingId, setRestartingId] = useState<string | null>(null);
+  const [roleFilter, setRoleFilter] = useState<string>("all");
+  const { currentSlug, roles } = useRoleSlug();
+
+  const filteredWorkflows = workflows.filter((w) => {
+    if (roleFilter === "all") return true;
+    const slug = roleFilter === "mine" ? currentSlug : roleFilter;
+    if (!slug) return true;
+    return w.creatorRole === slug || (w.assignedRoles ?? []).includes(slug);
+  });
 
   useEffect(() => {
     const fetchWorkflows = () => {
@@ -172,17 +185,34 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
       {/* Header */}
       <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
         <h2 className="text-sm font-semibold text-zinc-200">Requirements</h2>
-        <button
-          onClick={onNewWorkflow}
-          className="px-3 py-1.5 text-xs rounded-md bg-indigo-600 hover:bg-indigo-500 transition-colors"
-        >
-          + New Requirement
-        </button>
+        <div className="flex items-center gap-2">
+          <select
+            value={roleFilter}
+            onChange={(e) => setRoleFilter(e.target.value)}
+            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-600"
+          >
+            <option value="all">All Roles</option>
+            <option value="mine">My Role{currentSlug ? ` (${currentSlug})` : ""}</option>
+            {roles.map((r) => (
+              <option key={r.slug} value={r.slug}>{r.label}</option>
+            ))}
+          </select>
+          <button
+            onClick={onNewWorkflow}
+            className="px-3 py-1.5 text-xs rounded-md bg-indigo-600 hover:bg-indigo-500 transition-colors"
+          >
+            + New Requirement
+          </button>
+        </div>
       </div>
 
       {/* Tree list */}
       <div className="flex-1 overflow-y-auto p-4">
-        {workflows.length === 0 ? (
+        {filteredWorkflows.length === 0 && workflows.length > 0 ? (
+          <div className="p-8 text-center">
+            <p className="text-zinc-500 text-sm">No requirements match the selected role filter</p>
+          </div>
+        ) : filteredWorkflows.length === 0 ? (
           <div className="p-8 text-center">
             <p className="text-zinc-500 text-sm mb-3">No requirements yet</p>
             <button
@@ -194,7 +224,7 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
           </div>
         ) : (
           <div className="space-y-2">
-            {workflows.map((w) => {
+            {filteredWorkflows.map((w) => {
               const isExpanded = expandedIds.has(w.id);
               const effectivePhase = getEffectivePhase(w, taskStatuses);
               const failed = effectivePhase === "failed";
@@ -227,6 +257,12 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
                       <div className="flex items-center justify-between gap-3">
                         <span className="text-sm text-zinc-200 truncate">{title}</span>
                         <div className="flex items-center gap-2 shrink-0">
+                          {w.creatorRole && (
+                            <RoleTagBadge role={w.creatorRole} variant="creator" />
+                          )}
+                          {(w.assignedRoles ?? []).map((r: string) => (
+                            <RoleTagBadge key={r} role={r} />
+                          ))}
                           <span className="text-[10px] text-zinc-600">
                             {new Date(w.updatedAt).toLocaleDateString()}
                           </span>

--- a/src/components/shared/RoleTagBadge.tsx
+++ b/src/components/shared/RoleTagBadge.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+const ROLE_COLORS: Record<string, string> = {
+  dev: "bg-blue-600/20 text-blue-400 border-blue-600/30",
+  pm: "bg-purple-600/20 text-purple-400 border-purple-600/30",
+  test: "bg-amber-600/20 text-amber-400 border-amber-600/30",
+  design: "bg-pink-600/20 text-pink-400 border-pink-600/30",
+  hr: "bg-emerald-600/20 text-emerald-400 border-emerald-600/30",
+  finance: "bg-cyan-600/20 text-cyan-400 border-cyan-600/30",
+  sales: "bg-orange-600/20 text-orange-400 border-orange-600/30",
+  stakeholder: "bg-zinc-600/20 text-zinc-400 border-zinc-600/30",
+};
+
+const DEFAULT_COLOR = "bg-zinc-600/20 text-zinc-400 border-zinc-600/30";
+
+export function RoleTagBadge({
+  role,
+  variant = "default",
+}: {
+  role: string;
+  /** "creator" shows a small marker to distinguish creator vs assigned */
+  variant?: "default" | "creator";
+}) {
+  const color = ROLE_COLORS[role] ?? DEFAULT_COLOR;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded border ${color}`}
+      title={variant === "creator" ? `Created by ${role}` : `Assigned to ${role}`}
+    >
+      {variant === "creator" && (
+        <span className="text-[8px] opacity-60">by</span>
+      )}
+      {role}
+    </span>
+  );
+}

--- a/src/components/shared/useRoleSlug.ts
+++ b/src/components/shared/useRoleSlug.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useUser } from "@/components/user/UserContext";
+
+interface RoleInfo {
+  slug: string;
+  label: string;
+  userRole: string;
+}
+
+/**
+ * Returns the current user's role slug (e.g. "dev", "pm") and a list
+ * of all available role slugs for use in tag selectors / filters.
+ */
+export function useRoleSlug() {
+  const { role } = useUser();
+  const [roles, setRoles] = useState<RoleInfo[]>([]);
+
+  useEffect(() => {
+    fetch("/api/roles")
+      .then((r) => r.json())
+      .then((d) => setRoles(d.roles ?? []))
+      .catch(() => {});
+  }, []);
+
+  const currentSlug = roles.find((r) => r.userRole === role)?.slug ?? null;
+
+  return { currentSlug, roles };
+}

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -4,11 +4,14 @@ import { useEffect, useState } from "react";
 import type { FaceTask } from "@/lib/tasks/types";
 import { TaskRow } from "./TaskRow";
 import { TaskDetail } from "./TaskDetail";
+import { useRoleSlug } from "@/components/shared/useRoleSlug";
 
 export function TaskList() {
   const [tasks, setTasks] = useState<FaceTask[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<string>("all");
+  const [roleFilter, setRoleFilter] = useState<string>("all");
+  const { currentSlug, roles } = useRoleSlug();
 
   async function loadTasks() {
     try {
@@ -26,8 +29,16 @@ export function TaskList() {
     return () => clearInterval(interval);
   }, []);
 
-  const filtered =
-    filter === "all" ? tasks : tasks.filter((t) => t.status === filter);
+  const filtered = tasks.filter((t) => {
+    if (filter !== "all" && t.status !== filter) return false;
+    if (roleFilter !== "all") {
+      const slug = roleFilter === "mine" ? currentSlug : roleFilter;
+      if (!slug) return true;
+      const matches = t.creatorRole === slug || (t.assignedRoles ?? []).includes(slug);
+      if (!matches) return false;
+    }
+    return true;
+  });
 
   async function handleDelete(taskId: string) {
     try {
@@ -65,17 +76,30 @@ export function TaskList() {
               <span className="ml-2 text-zinc-600">({tasks.length})</span>
             )}
           </h2>
-          <select
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-600"
-          >
-            <option value="all">All</option>
-            <option value="running">Running</option>
-            <option value="pending">Pending</option>
-            <option value="completed">Completed</option>
-            <option value="failed">Failed</option>
-          </select>
+          <div className="flex items-center gap-1.5">
+            <select
+              value={roleFilter}
+              onChange={(e) => setRoleFilter(e.target.value)}
+              className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-600"
+            >
+              <option value="all">All Roles</option>
+              <option value="mine">My Role{currentSlug ? ` (${currentSlug})` : ""}</option>
+              {roles.map((r) => (
+                <option key={r.slug} value={r.slug}>{r.label}</option>
+              ))}
+            </select>
+            <select
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-600"
+            >
+              <option value="all">All</option>
+              <option value="running">Running</option>
+              <option value="pending">Pending</option>
+              <option value="completed">Completed</option>
+              <option value="failed">Failed</option>
+            </select>
+          </div>
         </div>
         <div className="space-y-2 overflow-y-auto flex-1 min-h-0">
           {filtered.length === 0 ? (

--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -3,6 +3,7 @@
 import type { FaceTask } from "@/lib/tasks/types";
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import { RelativeTime } from "@/components/shared/RelativeTime";
+import { RoleTagBadge } from "@/components/shared/RoleTagBadge";
 
 export function TaskRow({
   task,
@@ -115,6 +116,10 @@ export function TaskRow({
       {/* Meta */}
       <div className="mt-2 flex items-center gap-3 text-xs text-zinc-500">
         <span className="font-mono">{task.agent}</span>
+        {task.creatorRole && <RoleTagBadge role={task.creatorRole} variant="creator" />}
+        {task.assignedRoles?.map((r) => (
+          <RoleTagBadge key={r} role={r} />
+        ))}
         <RelativeTime date={task.updatedAt} />
       </div>
 

--- a/src/components/tasks/TaskSubmit.tsx
+++ b/src/components/tasks/TaskSubmit.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { useRoleSlug } from "@/components/shared/useRoleSlug";
 
 interface Agent {
   id: string;
@@ -25,6 +26,7 @@ export function TaskSubmit({
     type: "success" | "error";
   } | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { currentSlug: userRoleSlug } = useRoleSlug();
 
   useEffect(() => {
     fetch("/api/agents")
@@ -58,6 +60,8 @@ export function TaskSubmit({
         body: JSON.stringify({
           agentId: selectedAgent,
           prompt: prompt.trim(),
+          creatorRole: userRoleSlug ?? undefined,
+          assignedRoles: userRoleSlug ? [userRoleSlug] : undefined,
         }),
       });
       const data = await res.json();

--- a/src/lib/project/workflow.ts
+++ b/src/lib/project/workflow.ts
@@ -46,6 +46,10 @@ export interface WorkflowState {
   engApproval: ApprovalStatus;
   taskId: string | null;        // FACE task ID once implementation starts
   pr: PullRequestInfo | null;   // PR created after implementation
+  /** Role slug of the user who created this requirement (e.g. "pm", "dev") */
+  creatorRole: string | null;
+  /** Role slugs relevant to this requirement (e.g. ["dev", "pm"]) */
+  assignedRoles: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -67,7 +71,11 @@ export function loadWorkflow(id: string): WorkflowState | null {
   const path = join(WORKFLOW_DIR, `${id}.json`);
   if (!existsSync(path)) return null;
   try {
-    return JSON.parse(readFileSync(path, "utf-8"));
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    // Backfill fields added after initial schema
+    if (!("creatorRole" in raw)) raw.creatorRole = null;
+    if (!("assignedRoles" in raw)) raw.assignedRoles = [];
+    return raw;
   } catch {
     return null;
   }
@@ -90,7 +98,7 @@ export function listWorkflows(): WorkflowState[] {
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
 }
 
-export function createWorkflow(): WorkflowState {
+export function createWorkflow(options?: { creatorRole?: string; assignedRoles?: string[] }): WorkflowState {
   const id = `wf-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const now = new Date().toISOString();
   const w: WorkflowState = {
@@ -104,6 +112,8 @@ export function createWorkflow(): WorkflowState {
     engApproval: "pending",
     taskId: null,
     pr: null,
+    creatorRole: options?.creatorRole ?? null,
+    assignedRoles: options?.assignedRoles ?? [],
     createdAt: now,
     updatedAt: now,
   };

--- a/src/lib/roles/registry.ts
+++ b/src/lib/roles/registry.ts
@@ -350,3 +350,15 @@ export function getRoleSlugs(): string[] {
 export function registerRole(definition: RoleDefinition): void {
   roles.set(definition.slug, definition);
 }
+
+/**
+ * Look up a role slug by its UserRole value (e.g. "engineer" → "dev").
+ * Returns the UserRole string itself as fallback if no match is found.
+ */
+export function getRoleSlugByUserRole(userRole: string): string {
+  initRegistry();
+  for (const def of roles.values()) {
+    if (def.userRole === userRole) return def.slug;
+  }
+  return userRole;
+}

--- a/src/lib/tasks/runner.ts
+++ b/src/lib/tasks/runner.ts
@@ -63,6 +63,8 @@ export async function submitTask(
     workingDirectory?: string;
     title?: string;
     linkedIssue?: number;
+    creatorRole?: string;
+    assignedRoles?: string[];
   }
 ): Promise<{ taskId: string; error?: string }> {
   const config = readConfig();
@@ -96,6 +98,8 @@ export async function submitTask(
     activities: [],
     result: null,
     linkedIssue: options?.linkedIssue,
+    creatorRole: options?.creatorRole,
+    assignedRoles: options?.assignedRoles,
   };
 
   // Write initial task file

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -45,6 +45,10 @@ export interface FaceTask {
   sessionId?: string;
   /** GitHub issue number to post completion summaries to */
   linkedIssue?: number;
+  /** Role slug of the user who created this task (e.g. "pm", "dev") */
+  creatorRole?: string;
+  /** Role slugs relevant to this task (e.g. ["dev", "pm"]) */
+  assignedRoles?: string[];
 }
 
 export interface AgentDetection {


### PR DESCRIPTION
## Summary
When a new requirement or task is created in FACE, it should be automatically synced to the user's configured project management tool — GitHub Projects or Linear. Each requirement/task should be tagged with both the creator role (e.g., PM) and assigned/relevant roles (e.g., Dev, PM). The tasks page should support filtering by these role tags so each role sees the work relevant to them.

## Acceptance Criteria
- [ ] When a requirement is created in FACE, a corresponding item is created in the configured PM tool (GitHub Projects)
- [ ] When a requirement is created in FACE and Linear is configured, a corresponding Linear issue is created instead
- [ ] Each synced item includes a **creator role** tag (the role of the user who created it)
- [ ] Each synced item includes one or more **assigned/relevant role** tags (roles that need to track it)
- [ ] Role tags are visible on requirement and task items in the FACE UI
- [ ] The tasks page supports filtering tasks by role tag
- [ ] Filtered views correctly show tasks where the current user's role matches either creator or assigned role
- [ ] PM tool sync includes the role tags as labels/tags in the external system

## Technical Notes
- The PM tool integration should be abstracted behind a common interface so GitHub Projects and Linear are interchangeable adapters
- GitHub Projects API uses GraphQL (ProjectV2); Linear has a REST/GraphQL API — both support custom fields or labels for role tags
- Role tags should be stored on the FACE requirement/task model as well as synced externally
- Consider a configuration setting for which PM tool is active (e.g., `projectManagement: 'github' | 'linear'`)
- Sync should happen on creation; bidirectional sync (external → FACE) is a separate concern

## Out of Scope
- Bidirectional sync (pulling updates from GitHub Projects or Linear back into FACE)
- Creating GitHub repo issues (this targets PM tool items only)
- Real-time sync or webhook-based updates from external PM tools
- Role-based access control or permissions — this is about tagging and filtering, not restricting access

<sub>Automatically created by FACE for workflow `wf-1774811519864-qnjf`</sub>