### PR TITLE
Add pagination to all list views

### DIFF
--- a/src/app/api/project/issues/route.ts
+++ b/src/app/api/project/issues/route.ts
@@ -16,8 +16,18 @@ export async function GET(req: Request) {
     search: url.searchParams.get("search") ?? undefined,
   };
 
-  const issues = await provider.listIssues(filter);
-  return NextResponse.json({ issues });
+  const allIssues = await provider.listIssues(filter);
+
+  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1);
+  const limit = Math.max(1, Math.min(100, parseInt(url.searchParams.get("limit") ?? "0", 10) || 0));
+
+  if (limit > 0) {
+    const offset = (page - 1) * limit;
+    const issues = allIssues.slice(offset, offset + limit);
+    return NextResponse.json({ issues, total: allIssues.length, page, limit });
+  }
+
+  return NextResponse.json({ issues: allIssues });
 }
 
 export async function POST(req: Request) {

--- a/src/components/project/IssueListView.tsx
+++ b/src/components/project/IssueListView.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import type { Issue, IssueStatus } from "@/lib/project/types";
 import { useProjectEvents } from "@/lib/project/use-project-events";
+import { Pagination, PAGE_SIZE } from "@/components/shared/Pagination";
 
 interface Props {
   onSelectIssue: (id: string) => void;
@@ -29,36 +30,60 @@ const STATUS_DOT: Record<string, string> = {
 
 export function IssueListView({ onSelectIssue, onAssignAgent }: Props) {
   const [issues, setIssues] = useState<Issue[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
+  const [pageLoading, setPageLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [showCreate, setShowCreate] = useState(false);
+  const initialLoad = useRef(true);
 
-  const fetchIssues = useCallback(() => {
+  const fetchIssues = useCallback((targetPage: number = page) => {
     const params = new URLSearchParams();
     if (search) params.set("search", search);
     if (statusFilter !== "all") params.set("status", statusFilter);
+    params.set("page", String(targetPage));
+    params.set("limit", String(PAGE_SIZE));
+
+    if (!initialLoad.current) setPageLoading(true);
 
     fetch(`/api/project/issues?${params}`)
       .then((r) => r.json())
       .then((data) => {
         if (data.error) setError(data.error);
-        else setIssues(data.issues);
+        else {
+          setIssues(data.issues);
+          setTotal(data.total ?? data.issues.length);
+        }
       })
       .catch((e) => setError(e.message))
-      .finally(() => setLoading(false));
+      .finally(() => {
+        setLoading(false);
+        setPageLoading(false);
+        initialLoad.current = false;
+      });
+  }, [search, statusFilter, page]);
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    setPage(1);
   }, [search, statusFilter]);
 
   useEffect(() => {
-    fetchIssues();
-    const interval = setInterval(fetchIssues, 30_000);
+    fetchIssues(page);
+    const interval = setInterval(() => fetchIssues(page), 30_000);
     return () => clearInterval(interval);
-  }, [fetchIssues]);
+  }, [fetchIssues, page]);
 
   useProjectEvents(() => {
-    fetchIssues();
+    fetchIssues(page);
   }, ["issue_created", "issue_updated"]);
+
+  const handlePageChange = (p: number) => {
+    setPage(p);
+  };
 
   if (error) {
     return (
@@ -117,7 +142,10 @@ export function IssueListView({ onSelectIssue, onAssignAgent }: Props) {
       {loading ? (
         <div className="animate-pulse text-zinc-500 py-8 text-center">Loading...</div>
       ) : (
-        <div className="border border-zinc-800 rounded-lg overflow-hidden">
+        <div className={`border border-zinc-800 rounded-lg overflow-hidden${pageLoading ? " opacity-60 pointer-events-none" : ""}`}>
+          {pageLoading && (
+            <div className="text-center py-1 text-xs text-zinc-500 animate-pulse">Loading page…</div>
+          )}
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-zinc-800 bg-zinc-900/50">
@@ -190,6 +218,14 @@ export function IssueListView({ onSelectIssue, onAssignAgent }: Props) {
             </tbody>
           </table>
         </div>
+      )}
+      {!loading && total > 0 && (
+        <Pagination
+          currentPage={page}
+          totalItems={total}
+          onPageChange={handlePageChange}
+          loading={pageLoading}
+        />
       )}
     </div>
   );

--- a/src/components/project/MilestoneView.tsx
+++ b/src/components/project/MilestoneView.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 import type { Milestone } from "@/lib/project/types";
+import { Pagination } from "@/components/shared/Pagination";
+import { usePagination } from "@/components/shared/usePagination";
 
 interface Props {
   onFilterBoard: (milestoneTitle: string) => void;
@@ -48,13 +50,28 @@ export function MilestoneView({ onFilterBoard }: Props) {
       {milestones.length === 0 ? (
         <p className="text-zinc-500 text-sm">No milestones found</p>
       ) : (
-        <div className="space-y-3">
-          {milestones.map((m) => (
-            <MilestoneCard key={m.id} milestone={m} onFilter={() => onFilterBoard(m.title)} />
-          ))}
-        </div>
+        <MilestoneList milestones={milestones} onFilterBoard={onFilterBoard} />
       )}
     </div>
+  );
+}
+
+function MilestoneList({ milestones, onFilterBoard }: { milestones: Milestone[]; onFilterBoard: (title: string) => void }) {
+  const { page, pageItems, totalItems, setPage } = usePagination(milestones);
+
+  return (
+    <>
+      <div className="space-y-3">
+        {pageItems.map((m) => (
+          <MilestoneCard key={m.id} milestone={m} onFilter={() => onFilterBoard(m.title)} />
+        ))}
+      </div>
+      <Pagination
+        currentPage={page}
+        totalItems={totalItems}
+        onPageChange={setPage}
+      />
+    </>
   );
 }
 

--- a/src/components/project/RequirementsView.tsx
+++ b/src/components/project/RequirementsView.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { RoleTagBadge } from "@/components/shared/RoleTagBadge";
 import { useRoleSlug } from "@/components/shared/useRoleSlug";
+import { Pagination } from "@/components/shared/Pagination";
+import { usePagination } from "@/components/shared/usePagination";
 
 interface ChatMessage {
   role: "user" | "assistant";
@@ -101,6 +103,12 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
     if (!slug) return true;
     return w.creatorRole === slug || (w.assignedRoles ?? []).includes(slug);
   });
+
+  const { page, pageItems: pagedWorkflows, totalItems, setPage, resetPage } = usePagination(filteredWorkflows);
+
+  useEffect(() => {
+    resetPage();
+  }, [roleFilter, resetPage]);
 
   useEffect(() => {
     const fetchWorkflows = () => {
@@ -233,12 +241,12 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
           </div>
         ) : (
           <div className="space-y-2">
-            {filteredWorkflows.map((w) => {
+            {pagedWorkflows.map((w) => {
               const isExpanded = expandedIds.has(w.id);
               const effectivePhase = getEffectivePhase(w, taskStatuses);
               const failed = effectivePhase === "failed";
               const cfg = PHASE_CONFIG[effectivePhase];
-              const title =
+              const title: string =
                 w.generatedStory?.title ??
                 w.messages.find((m) => m.role === "user")?.content.slice(0, 80) ??
                 "Untitled requirement";
@@ -417,6 +425,11 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
             })}
           </div>
         )}
+        <Pagination
+          currentPage={page}
+          totalItems={totalItems}
+          onPageChange={setPage}
+        />
       </div>
     </div>
   );

--- a/src/components/project/TriageView.tsx
+++ b/src/components/project/TriageView.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import type { IssuePriority } from "@/lib/project/types";
+import { Pagination } from "@/components/shared/Pagination";
+import { usePagination } from "@/components/shared/usePagination";
 
 interface TriageSuggestion {
   issueId: string;
@@ -95,6 +97,8 @@ export function TriageView() {
     }
   };
 
+  const { page, pageItems: pagedSuggestions, totalItems, setPage } = usePagination(suggestions);
+
   const PRIORITY_OPTIONS: IssuePriority[] = ["urgent", "high", "medium", "low", "none"];
 
   return (
@@ -167,7 +171,7 @@ export function TriageView() {
                 </tr>
               </thead>
               <tbody>
-                {suggestions.map((s) => (
+                {pagedSuggestions.map((s) => (
                   <tr key={s.issueId} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
                     <td className="px-4 py-2.5">
                       <input
@@ -210,6 +214,11 @@ export function TriageView() {
               </tbody>
             </table>
           </div>
+          <Pagination
+            currentPage={page}
+            totalItems={totalItems}
+            onPageChange={setPage}
+          />
         </>
       )}
 

--- a/src/components/shared/Pagination.tsx
+++ b/src/components/shared/Pagination.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+const PAGE_SIZE = 20;
+
+interface PaginationProps {
+  currentPage: number;
+  totalItems: number;
+  pageSize?: number;
+  onPageChange: (page: number) => void;
+  loading?: boolean;
+}
+
+export function Pagination({
+  currentPage,
+  totalItems,
+  pageSize = PAGE_SIZE,
+  onPageChange,
+  loading = false,
+}: PaginationProps) {
+  const totalPages = Math.ceil(totalItems / pageSize);
+
+  if (totalPages <= 1) return null;
+
+  const start = (currentPage - 1) * pageSize + 1;
+  const end = Math.min(currentPage * pageSize, totalItems);
+
+  return (
+    <div className="flex items-center justify-between px-1 py-3">
+      <span className="text-xs text-zinc-500 tabular-nums">
+        {start}–{end} of {totalItems}
+      </span>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage <= 1 || loading}
+          className="px-2 py-1 text-xs rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          ← Prev
+        </button>
+        {getPageNumbers(currentPage, totalPages).map((p, i) =>
+          p === "..." ? (
+            <span key={`ellipsis-${i}`} className="px-1 text-xs text-zinc-600">
+              …
+            </span>
+          ) : (
+            <button
+              key={p}
+              onClick={() => onPageChange(p as number)}
+              disabled={loading}
+              className={`px-2 py-1 text-xs rounded border transition-colors ${
+                p === currentPage
+                  ? "border-indigo-600 bg-indigo-600/20 text-indigo-400"
+                  : "border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800"
+              } disabled:cursor-not-allowed`}
+            >
+              {p}
+            </button>
+          ),
+        )}
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage >= totalPages || loading}
+          className="px-2 py-1 text-xs rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function getPageNumbers(
+  current: number,
+  total: number,
+): (number | "...")[] {
+  if (total <= 7) {
+    return Array.from({ length: total }, (_, i) => i + 1);
+  }
+
+  const pages: (number | "...")[] = [1];
+
+  if (current > 3) pages.push("...");
+
+  const rangeStart = Math.max(2, current - 1);
+  const rangeEnd = Math.min(total - 1, current + 1);
+
+  for (let i = rangeStart; i <= rangeEnd; i++) {
+    pages.push(i);
+  }
+
+  if (current < total - 2) pages.push("...");
+
+  pages.push(total);
+
+  return pages;
+}
+
+export { PAGE_SIZE };

--- a/src/components/shared/usePagination.ts
+++ b/src/components/shared/usePagination.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useMemo, useState, useCallback } from "react";
+import { PAGE_SIZE } from "./Pagination";
+
+interface UsePaginationOptions {
+  pageSize?: number;
+  initialPage?: number;
+}
+
+interface UsePaginationResult<T> {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  pageItems: T[];
+  setPage: (page: number) => void;
+  resetPage: () => void;
+}
+
+/**
+ * Client-side pagination hook: accepts the full array and returns
+ * the slice for the current page plus pagination metadata.
+ */
+export function usePagination<T>(
+  items: T[],
+  options: UsePaginationOptions = {},
+): UsePaginationResult<T> {
+  const pageSize = options.pageSize ?? PAGE_SIZE;
+  const [page, setPageRaw] = useState(options.initialPage ?? 1);
+
+  const totalItems = items.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+
+  // Clamp page if items shrink (e.g. after filtering)
+  const safePage = Math.min(page, totalPages);
+
+  const pageItems = useMemo(
+    () => items.slice((safePage - 1) * pageSize, safePage * pageSize),
+    [items, safePage, pageSize],
+  );
+
+  const setPage = useCallback(
+    (p: number) => setPageRaw(Math.max(1, Math.min(p, totalPages))),
+    [totalPages],
+  );
+
+  const resetPage = useCallback(() => setPageRaw(1), []);
+
+  return {
+    page: safePage,
+    pageSize,
+    totalItems,
+    pageItems,
+    setPage,
+    resetPage,
+  };
+}

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -5,6 +5,8 @@ import type { FaceTask } from "@/lib/tasks/types";
 import { TaskRow } from "./TaskRow";
 import { TaskDetail } from "./TaskDetail";
 import { useRoleSlug } from "@/components/shared/useRoleSlug";
+import { Pagination } from "@/components/shared/Pagination";
+import { usePagination } from "@/components/shared/usePagination";
 
 export function TaskList() {
   const [tasks, setTasks] = useState<FaceTask[]>([]);
@@ -39,6 +41,13 @@ export function TaskList() {
     }
     return true;
   });
+
+  const { page, pageItems, totalItems, setPage, resetPage } = usePagination(filtered);
+
+  // Reset page when filters change
+  useEffect(() => {
+    resetPage();
+  }, [filter, roleFilter, resetPage]);
 
   async function handleDelete(taskId: string) {
     try {
@@ -113,7 +122,7 @@ export function TaskList() {
               </p>
             </div>
           ) : (
-            filtered.map((task) => (
+            pageItems.map((task) => (
               <TaskRow
                 key={task.id}
                 task={task}
@@ -125,6 +134,11 @@ export function TaskList() {
             ))
           )}
         </div>
+        <Pagination
+          currentPage={page}
+          totalItems={totalItems}
+          onPageChange={setPage}
+        />
       </div>
 
       {/* Detail column */}


### PR DESCRIPTION
## Summary
List views across the application (requirements, projects, tasks, etc.) have grown too long and need pagination. Server-side pagination should be used where the API supports it, with client-side pagination as a fallback. Default page size is 20 items per page.

## Acceptance Criteria
- [ ] All list views (requirements, projects, tasks) display a maximum of 20 items per page by default
- [ ] Pagination controls (prev/next and page indicators) are shown when items exceed the page size
- [ ] Server-side pagination is used for APIs that support it (offset/limit or cursor-based)
- [ ] Client-side pagination is used as a fallback when the API does not support pagination
- [ ] Page state is preserved when navigating back to a list from a detail view
- [ ] Empty and single-page lists do not show pagination controls
- [ ] Loading states are shown during page transitions for server-side paginated lists

## Technical Notes
- Audit existing API endpoints to determine which support pagination parameters
- Build a reusable pagination component that works for both server-side and client-side modes
- For client-side pagination, fetch all data upfront and slice in the UI
- For server-side pagination, pass page/offset params and handle total count from the API response
- Consider using query params (e.g. `?page=2`) so paginated state is shareable via URL

## Out of Scope
- Infinite scroll / virtual scrolling
- User-configurable page size
- Sorting or filtering changes (separate concern)
- Search within paginated results

<sub>Automatically created by FACE for workflow `wf-1774839624029-scz0`</sub>