### PR TITLE
Fix premature requirement completion and enforce main-based branching

### DIFF
--- a/src/app/api/project/workflow/[workflowId]/chat/route.ts
+++ b/src/app/api/project/workflow/[workflowId]/chat/route.ts
@@ -318,22 +318,16 @@ export async function POST(
         { status: 400 }
       );
     }
+
+    // If this workflow has a linked issue (PR-based workflow), don't mark done —
+    // the PR merge poller will transition to "done" when the PR is merged.
+    if (workflow.issueId) {
+      return NextResponse.json({ workflow });
+    }
+
     workflow.phase = "done";
     workflow.updatedAt = new Date().toISOString();
     saveWorkflow(workflow);
-
-    // Close the linked GitHub issue
-    if (workflow.issueId) {
-      const provider = await getActiveProvider();
-      if (provider) {
-        try {
-          await provider.updateIssue(workflow.issueId, { status: "done" });
-          await provider.addComment(workflow.issueId, "Implementation completed. Closing issue.");
-        } catch {
-          // best-effort
-        }
-      }
-    }
 
     return NextResponse.json({ workflow });
   }

--- a/src/app/api/project/workflow/__tests__/complete-action.test.ts
+++ b/src/app/api/project/workflow/__tests__/complete-action.test.ts
@@ -58,24 +58,17 @@ describe("complete action", () => {
     vi.clearAllMocks();
   });
 
-  it("should transition workflow to done and close GitHub issue", async () => {
-    const updateIssue = vi.fn().mockResolvedValue(undefined);
-    const addComment = vi.fn().mockResolvedValue(undefined);
-    mockedGetActiveProvider.mockResolvedValue({
-      updateIssue,
-      addComment,
-    } as any);
-
+  it("should not transition to done when issueId is present (PR-based workflow)", async () => {
     const workflow = buildWorkflow({ issueId: "123" });
     mockedLoadWorkflow.mockReturnValue(workflow as any);
 
     const response = await POST(makeRequest({ action: "complete" }), makeParams());
     const data = await response.json();
 
-    expect(data.workflow.phase).toBe("done");
-    expect(mockedSaveWorkflow).toHaveBeenCalledTimes(1);
-    expect(updateIssue).toHaveBeenCalledWith("123", { status: "done" });
-    expect(addComment).toHaveBeenCalledWith("123", expect.stringContaining("completed"));
+    // PR-based workflows stay in "implementing" — the PR merge poller handles "done"
+    expect(data.workflow.phase).toBe("implementing");
+    expect(mockedSaveWorkflow).not.toHaveBeenCalled();
+    expect(mockedGetActiveProvider).not.toHaveBeenCalled();
   });
 
   it("should return current state if already done (idempotent)", async () => {
@@ -117,21 +110,15 @@ describe("complete action", () => {
     expect(mockedGetActiveProvider).not.toHaveBeenCalled();
   });
 
-  it("should handle provider errors gracefully", async () => {
-    const updateIssue = vi.fn().mockRejectedValue(new Error("GitHub API down"));
-    const addComment = vi.fn().mockResolvedValue(undefined);
-    mockedGetActiveProvider.mockResolvedValue({
-      updateIssue,
-      addComment,
-    } as any);
-
+  it("should be a no-op for PR-based workflows even with provider errors", async () => {
     const workflow = buildWorkflow({ issueId: "123" });
     mockedLoadWorkflow.mockReturnValue(workflow as any);
 
     const response = await POST(makeRequest({ action: "complete" }), makeParams());
     const data = await response.json();
 
-    expect(data.workflow.phase).toBe("done");
-    expect(mockedSaveWorkflow).toHaveBeenCalled();
+    // PR-based workflows are deferred to the poller — no state change
+    expect(data.workflow.phase).toBe("implementing");
+    expect(mockedSaveWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/src/components/project/RequirementWorkflow.tsx
+++ b/src/components/project/RequirementWorkflow.tsx
@@ -30,6 +30,7 @@ interface PullRequestInfo {
   repo: string;
   branch: string;
   status: "open" | "merged" | "closed";
+  conflicted?: boolean;
 }
 
 interface WorkflowState {
@@ -698,13 +699,20 @@ function ImplementingView({
   onTaskRestarted: (newTaskId: string) => void;
 }) {
   const [restarting, setRestarting] = useState(false);
+  const [taskCompleted, setTaskCompleted] = useState(false);
 
   const handleStatusChange = useCallback(
     (status: string) => {
-      // Only auto-advance on success, not on failure
-      if (status === "completed") onDone();
+      // When a PR workflow is expected, don't mark done on task completion —
+      // the PR merge poller will handle the "done" transition.
+      // Only auto-advance for non-PR workflows (no issue linked).
+      if (status === "completed" && !workflow.issueId) {
+        onDone();
+      } else if (status === "completed") {
+        setTaskCompleted(true);
+      }
     },
-    [onDone]
+    [onDone, workflow.issueId]
   );
 
   const handleRestart = useCallback(
@@ -765,6 +773,34 @@ function ImplementingView({
 
       {restarting && (
         <p className="text-xs text-indigo-400 animate-pulse">Restarting task...</p>
+      )}
+
+      {taskCompleted && workflow.issueId && !workflow.pr?.conflicted && (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-indigo-600/10 border border-indigo-600/20">
+          <span className="text-indigo-400 text-sm animate-pulse">&#x231B;</span>
+          <span className="text-xs text-indigo-300">
+            Task completed — waiting for PR to be created and merged
+          </span>
+          {workflow.pr?.url && (
+            <a
+              href={workflow.pr.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-indigo-400 hover:text-indigo-300 ml-auto"
+            >
+              View PR ↗
+            </a>
+          )}
+        </div>
+      )}
+
+      {workflow.pr?.conflicted && (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-red-600/10 border border-red-600/20">
+          <span className="text-red-400 text-sm">!</span>
+          <span className="text-xs text-red-300">
+            Branch has conflicts with main that need manual resolution before a PR can be created
+          </span>
+        </div>
       )}
     </div>
   );

--- a/src/lib/project/pr-creator.ts
+++ b/src/lib/project/pr-creator.ts
@@ -54,9 +54,56 @@ export async function createPRForCompletedTask(task: FaceTask): Promise<void> {
       return;
     }
 
+    // Fetch latest base branch before pushing or creating PR
+    try {
+      execSync(`git fetch origin ${baseBranch}`, { cwd, encoding: "utf-8", stdio: "pipe" });
+    } catch {
+      // best-effort — remote may not be reachable
+    }
+
+    // Rebase onto latest base branch to minimize merge conflicts
+    try {
+      execSync(`git rebase origin/${baseBranch}`, { cwd, encoding: "utf-8", stdio: "pipe" });
+    } catch {
+      // Rebase failed — abort and report conflict
+      try {
+        execSync("git rebase --abort", { cwd, encoding: "utf-8", stdio: "pipe" });
+      } catch {
+        // already aborted or not in rebase state
+      }
+      console.error(
+        `[face] Rebase of ${branch} onto origin/${baseBranch} failed — conflicts need manual resolution`,
+      );
+      // Update workflow to surface the conflict to the user
+      const fresh = loadWorkflow(workflow.id);
+      if (fresh) {
+        fresh.pr = {
+          number: 0,
+          url: "",
+          repo: gh.getRepo(),
+          branch,
+          status: "open",
+          conflicted: true,
+        };
+        fresh.updatedAt = new Date().toISOString();
+        saveWorkflow(fresh);
+      }
+      if (workflow.issueId) {
+        try {
+          await gh.addComment(
+            workflow.issueId,
+            `Could not auto-create PR: branch \`${branch}\` has conflicts with \`${baseBranch}\` that need manual resolution.`,
+          );
+        } catch {
+          // best-effort
+        }
+      }
+      return;
+    }
+
     // Ensure the branch is pushed to the remote
     try {
-      execSync(`git push -u origin ${branch}`, { cwd, encoding: "utf-8", stdio: "pipe" });
+      execSync(`git push -u origin ${branch} --force-with-lease`, { cwd, encoding: "utf-8", stdio: "pipe" });
     } catch {
       // May already be pushed or no remote — try anyway
     }

--- a/src/lib/project/workflow.ts
+++ b/src/lib/project/workflow.ts
@@ -33,6 +33,7 @@ export interface PullRequestInfo {
   repo: string;          // "owner/repo"
   branch: string;
   status: "open" | "merged" | "closed"; // tracks current PR state
+  conflicted?: boolean;  // true when rebase onto base branch failed
 }
 
 export interface WorkflowState {
@@ -170,6 +171,6 @@ INSTRUCTIONS:
 - Implement all acceptance criteria
 - Write clean, production-quality code
 - Follow existing code patterns in the repository
-- Create a new branch for this work
+- Before starting, run: git fetch origin main && git checkout -b <feature-branch> origin/main
 - Commit with clear messages referencing the issue`;
 }


### PR DESCRIPTION
## Summary

Requirements are incorrectly marked as "done" when the implementing agent's task completes, before the PR is even created or merged. Additionally, feature branches are not guaranteed to be created from the latest `main`, which can lead to unresolved conflicts in PRs.

## Acceptance Criteria
- [ ] Requirements with a PR-based workflow are NOT marked "done" on agent task completion
- [ ] Requirements transition to "done" only when the associated PR is merged (via the existing poller)
- [ ] The UI stays in "implementing" phase after task completion until PR merge is confirmed
- [ ] Feature branches for requirement implementation are always created from latest `origin/main`
- [ ] Before PR creation, the branch is rebased or merged with `main` to resolve any conflicts
- [ ] If conflicts cannot be auto-resolved, the system surfaces this to the user rather than creating a conflicted PR

## Technical Notes
- **Bug 1 fix location**: `RequirementWorkflow.tsx` around line 703-705 — the `onStatusChange("completed")` → `onDone()` path needs to be gated. When a PR is expected, task completion should transition to a "waiting for merge" state instead of calling `markDone()`.
- **Bug 2 fix location**: `pr-creator.ts` around line 41-44 — before the agent starts work, run `git fetch origin main && git checkout -b <feature-branch> origin/main`. Before creating the PR, rebase onto `origin/main` and abort if there are unresolvable conflicts.
- The existing PR merge poller (commits #67/#69) already handles the "done on merge" transition correctly — this fix removes the competing UI path that bypasses it.

## Out of Scope
- Changes to the PR merge polling interval or mechanism
- Manual conflict resolution UI
- Changes to how non-code requirements (no PR expected) are marked done

<sub>Automatically created by FACE for workflow `wf-1774840508543-42ux`</sub>