### PR TITLE
Multi-project support with AI-driven project detection

### DIFF
--- a/src/app/api/project/workflow/[workflowId]/chat/route.ts
+++ b/src/app/api/project/workflow/[workflowId]/chat/route.ts
@@ -10,6 +10,7 @@ import {
 import { getActiveProvider } from "@/lib/project/manager";
 import { submitTask } from "@/lib/tasks/runner";
 import { buildImplementationPrompt } from "@/lib/project/workflow";
+import { listProjects, getProject } from "@/lib/projects/store";
 
 /**
  * POST /api/project/workflow/:id/chat
@@ -49,21 +50,53 @@ export async function POST(
     };
     workflow.messages.push(userMsg);
 
+    // Build project context for AI
+    const allProjects = listProjects();
+    let projectContext: { projectName?: string; repoLink?: string; allProjects?: { id: string; name: string; repoLink: string }[] } | undefined;
+
+    if (workflow.projectId) {
+      const proj = getProject(workflow.projectId);
+      if (proj) {
+        projectContext = { projectName: proj.name, repoLink: proj.repoLink };
+      }
+    } else if (allProjects.length > 1) {
+      // No project assigned yet — give AI the list so it can detect
+      projectContext = {
+        allProjects: allProjects.map((p) => ({ id: p.id, name: p.name, repoLink: p.repoLink })),
+      };
+    } else if (allProjects.length === 1) {
+      // Single project — auto-assign
+      workflow.projectId = allProjects[0].id;
+      projectContext = { projectName: allProjects[0].name, repoLink: allProjects[0].repoLink };
+    }
+
     // Call AI for response
     const aiReply = await callAI(
-      buildGatheringSystemPrompt(),
+      buildGatheringSystemPrompt(projectContext),
       workflow.messages
     );
 
+    // Check if AI detected a project
+    const projectMatch = aiReply.match(/\[PROJECT_ID:([^\]]+)\]/);
+    if (projectMatch && !workflow.projectId) {
+      const detectedId = projectMatch[1].trim();
+      if (allProjects.find((p) => p.id === detectedId)) {
+        workflow.projectId = detectedId;
+      }
+    }
+
+    // Strip project detection tag from the message shown to user
+    const cleanReply = aiReply.replace(/\[PROJECT_ID:[^\]]+\]/g, "").trim();
+
     const assistantMsg: ChatMessage = {
       role: "assistant",
-      content: aiReply,
+      content: cleanReply,
       timestamp: new Date().toISOString(),
     };
     workflow.messages.push(assistantMsg);
 
     // Check if AI signaled it has enough info
-    if (aiReply.includes("[READY_TO_PLAN]")) {
+    if (cleanReply.includes("[READY_TO_PLAN]")) {
       workflow.phase = "planning";
     }
 
@@ -345,6 +378,17 @@ export async function POST(
     workflow.updatedAt = new Date().toISOString();
     saveWorkflow(workflow);
     return NextResponse.json({ workflow });
+  }
+
+  // ── Update project assignment ──────────────────────────────────
+  if (body.action === "update_project") {
+    if (typeof body.projectId === "string" || body.projectId === null) {
+      workflow.projectId = body.projectId;
+      workflow.updatedAt = new Date().toISOString();
+      saveWorkflow(workflow);
+      return NextResponse.json({ workflow });
+    }
+    return NextResponse.json({ error: "projectId is required" }, { status: 400 });
   }
 
   return NextResponse.json({ error: "Unknown action" }, { status: 400 });

--- a/src/app/api/project/workflow/route.ts
+++ b/src/app/api/project/workflow/route.ts
@@ -1,18 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createWorkflow, listWorkflows } from "@/lib/project/workflow";
 
-export async function GET() {
-  const workflows = listWorkflows();
+export async function GET(request: NextRequest) {
+  const projectId = request.nextUrl.searchParams.get("projectId");
+  let workflows = listWorkflows();
+
+  // Filter by project if requested
+  if (projectId) {
+    workflows = workflows.filter((w) => w.projectId === projectId);
+  }
+
   return NextResponse.json({ workflows });
 }
 
 export async function POST(request: NextRequest) {
   let creatorRole: string | undefined;
   let assignedRoles: string[] | undefined;
+  let projectId: string | undefined;
 
   try {
     const body = await request.json();
     if (typeof body.creatorRole === "string") creatorRole = body.creatorRole;
+    if (typeof body.projectId === "string") projectId = body.projectId;
     if (Array.isArray(body.assignedRoles)) {
       assignedRoles = body.assignedRoles.filter((r: unknown) => typeof r === "string");
     }
@@ -20,6 +29,6 @@ export async function POST(request: NextRequest) {
     // No body or invalid JSON — proceed with defaults
   }
 
-  const workflow = createWorkflow({ creatorRole, assignedRoles });
+  const workflow = createWorkflow({ creatorRole, assignedRoles, projectId });
   return NextResponse.json({ workflow });
 }

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getProject, updateProject, deleteProject } from "@/lib/projects/store";
+
+/** GET /api/projects/:id — get a single project */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const { projectId } = await params;
+  const project = getProject(projectId);
+  if (!project) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+  return NextResponse.json({ project });
+}
+
+/** PATCH /api/projects/:id — update a project */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const { projectId } = await params;
+  try {
+    const body = await request.json();
+    const updates: { name?: string; repoLink?: string } = {};
+    if (typeof body.name === "string") updates.name = body.name.trim();
+    if (typeof body.repoLink === "string") updates.repoLink = body.repoLink.trim();
+
+    const project = updateProject(projectId, updates);
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+    return NextResponse.json({ project });
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+}
+
+/** DELETE /api/projects/:id — remove a project */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  const { projectId } = await params;
+  const deleted = deleteProject(projectId);
+  if (!deleted) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/projects/active/route.ts
+++ b/src/app/api/projects/active/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getActiveProject, setActiveProjectId } from "@/lib/projects/store";
+
+/** GET /api/projects/active — get the currently active project */
+export async function GET() {
+  const project = getActiveProject();
+  return NextResponse.json({ project });
+}
+
+/** PUT /api/projects/active — set the active project */
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const projectId = typeof body.projectId === "string" ? body.projectId : null;
+
+    const ok = setActiveProjectId(projectId);
+    if (!ok) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, activeProjectId: projectId });
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+}

--- a/src/app/api/projects/migrate/route.ts
+++ b/src/app/api/projects/migrate/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { listWorkflows, saveWorkflow } from "@/lib/project/workflow";
+import { listProjects, getActiveProjectId } from "@/lib/projects/store";
+
+/**
+ * POST /api/projects/migrate
+ *
+ * Migrates existing workflows that have no projectId to the active project
+ * (or the first project if no active project is set). This is a one-time
+ * migration for transitioning from single-project to multi-project.
+ */
+export async function POST() {
+  const projects = listProjects();
+  if (projects.length === 0) {
+    return NextResponse.json({ migrated: 0, message: "No projects exist yet" });
+  }
+
+  const activeId = getActiveProjectId();
+  const targetProjectId = activeId ?? projects[0].id;
+
+  const workflows = listWorkflows();
+  let migrated = 0;
+
+  for (const w of workflows) {
+    if (!w.projectId) {
+      w.projectId = targetProjectId;
+      w.updatedAt = new Date().toISOString();
+      saveWorkflow(w);
+      migrated++;
+    }
+  }
+
+  return NextResponse.json({ migrated, targetProjectId });
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listProjects, createProject } from "@/lib/projects/store";
+
+/** GET /api/projects — list all projects */
+export async function GET() {
+  const projects = listProjects();
+  return NextResponse.json({ projects });
+}
+
+/** POST /api/projects — create a new project */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const repoLink = typeof body.repoLink === "string" ? body.repoLink.trim() : "";
+
+    if (!name) {
+      return NextResponse.json({ error: "Project name is required" }, { status: 400 });
+    }
+
+    const project = createProject(name, repoLink);
+    return NextResponse.json({ project });
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+}

--- a/src/components/project/ProjectDashboard.tsx
+++ b/src/components/project/ProjectDashboard.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/roles/project-views";
 import type { SidebarLink } from "@/lib/roles/types";
 import { WidgetRenderer } from "@/components/widgets/WidgetRenderer";
+import { useActiveProject } from "@/components/projects/ProjectSelector";
 
 const STORAGE_KEY = "face-project-view";
 
@@ -40,6 +41,7 @@ export function ProjectDashboard() {
 
   const [activeRole, setActiveRole] = useState<ProjectViewKey>(resolveRole);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const { activeProjectId, projects, setActive: setActiveProject } = useActiveProject();
 
   const role = PROJECT_VIEWS[activeRole];
 
@@ -187,6 +189,21 @@ export function ProjectDashboard() {
           </Link>
         </div>
 
+        {/* Project switcher */}
+        {projects.length > 1 && (
+          <div className="border-b border-zinc-800 px-3 py-2">
+            <select
+              value={activeProjectId ?? ""}
+              onChange={(e) => setActiveProject(e.target.value || null)}
+              className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-indigo-600"
+            >
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
         {/* Role tabs in sidebar */}
         <div className="border-b border-zinc-800 px-3 py-2">
           {roleTabs}
@@ -248,6 +265,21 @@ export function ProjectDashboard() {
                 </svg>
               </button>
             </div>
+
+            {/* Project switcher (mobile) */}
+            {projects.length > 1 && (
+              <div className="border-b border-zinc-800 px-4 py-2">
+                <select
+                  value={activeProjectId ?? ""}
+                  onChange={(e) => setActiveProject(e.target.value || null)}
+                  className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1.5 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-indigo-600"
+                >
+                  {projects.map((p) => (
+                    <option key={p.id} value={p.id}>{p.name}</option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             {/* Role tabs in mobile sidebar */}
             <div className="border-b border-zinc-800 px-4 py-2">

--- a/src/components/project/RequirementWorkflow.tsx
+++ b/src/components/project/RequirementWorkflow.tsx
@@ -46,6 +46,7 @@ interface WorkflowState {
   pr: PullRequestInfo | null;
   creatorRole: string | null;
   assignedRoles: string[];
+  projectId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -100,9 +101,11 @@ interface Props {
   workflowId?: string | null; // if provided, load existing workflow
   onClose: () => void;
   onCreated: () => void; // refresh parent
+  /** Project to associate with new workflows */
+  activeProjectId?: string | null;
 }
 
-export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
+export function RequirementWorkflow({ workflowId, onClose, onCreated, activeProjectId }: Props) {
   const [workflow, setWorkflow] = useState<WorkflowState | null>(null);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -133,6 +136,7 @@ export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
         pr: null,
         creatorRole: null,
         assignedRoles: [],
+        projectId: activeProjectId ?? null,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       });
@@ -196,6 +200,7 @@ export function RequirementWorkflow({ workflowId, onClose, onCreated }: Props) {
           body: JSON.stringify({
             creatorRole: userRoleSlug ?? undefined,
             assignedRoles: userRoleSlug ? [userRoleSlug] : [],
+            projectId: activeProjectId ?? undefined,
           }),
         });
         const createData = await createRes.json();

--- a/src/components/project/RequirementsView.tsx
+++ b/src/components/project/RequirementsView.tsx
@@ -43,8 +43,15 @@ interface WorkflowState {
   pr: PullRequestInfo | null;
   creatorRole: string | null;
   assignedRoles: string[];
+  projectId: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+interface ProjectInfo {
+  id: string;
+  name: string;
+  repoLink: string;
 }
 
 interface TaskInfo {
@@ -86,18 +93,25 @@ function getEffectivePhase(w: WorkflowState, taskStatuses: Record<string, TaskIn
 interface Props {
   onSelectWorkflow: (id: string) => void;
   onNewWorkflow: () => void;
+  /** When set, filter workflows to this project and pass to new workflows */
+  activeProjectId?: string | null;
 }
 
-export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
+export function RequirementsView({ onSelectWorkflow, onNewWorkflow, activeProjectId }: Props) {
   const [workflows, setWorkflows] = useState<WorkflowState[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [taskStatuses, setTaskStatuses] = useState<Record<string, TaskInfo>>({});
   const [restartingId, setRestartingId] = useState<string | null>(null);
   const [roleFilter, setRoleFilter] = useState<string>("all");
+  const [projectFilter, setProjectFilter] = useState<string>(activeProjectId ?? "all");
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const { currentSlug, roles } = useRoleSlug();
 
   const filteredWorkflows = workflows.filter((w) => {
+    // Project filter
+    if (projectFilter !== "all" && w.projectId !== projectFilter) return false;
+    // Role filter
     if (roleFilter === "all") return true;
     const slug = roleFilter === "mine" ? currentSlug : roleFilter;
     if (!slug) return true;
@@ -108,7 +122,15 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
 
   useEffect(() => {
     resetPage();
-  }, [roleFilter, resetPage]);
+  }, [roleFilter, projectFilter, resetPage]);
+
+  // Fetch projects for the filter dropdown
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((r) => r.json())
+      .then((d) => setProjects(d.projects ?? []))
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     const fetchWorkflows = () => {
@@ -203,6 +225,18 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
       <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
         <h2 className="text-sm font-semibold text-zinc-200">Requirements</h2>
         <div className="flex items-center gap-2">
+          {projects.length > 1 && (
+            <select
+              value={projectFilter}
+              onChange={(e) => setProjectFilter(e.target.value)}
+              className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:ring-1 focus:ring-indigo-600"
+            >
+              <option value="all">All Projects</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          )}
           <select
             value={roleFilter}
             onChange={(e) => setRoleFilter(e.target.value)}
@@ -283,6 +317,14 @@ export function RequirementsView({ onSelectWorkflow, onNewWorkflow }: Props) {
                           {(w.assignedRoles ?? []).map((r: string) => (
                             <RoleTagBadge key={r} role={r} />
                           ))}
+                          {w.projectId && projects.length > 1 && (() => {
+                            const proj = projects.find((p) => p.id === w.projectId);
+                            return proj ? (
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-500 border border-zinc-700">
+                                {proj.name}
+                              </span>
+                            ) : null;
+                          })()}
                           <span className="text-[10px] text-zinc-600">
                             {new Date(w.updatedAt).toLocaleDateString()}
                           </span>

--- a/src/components/projects/ProjectManager.tsx
+++ b/src/components/projects/ProjectManager.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+interface Project {
+  id: string;
+  name: string;
+  repoLink: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Full project management UI: list, add, edit, remove projects.
+ * Used as a widget or standalone view in role dashboards.
+ */
+export function ProjectManager() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingProject, setEditingProject] = useState<Project | null>(null);
+  const [formName, setFormName] = useState("");
+  const [formRepoLink, setFormRepoLink] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const fetchProjects = useCallback(async () => {
+    try {
+      const [projRes, activeRes] = await Promise.all([
+        fetch("/api/projects"),
+        fetch("/api/projects/active"),
+      ]);
+      const projData = await projRes.json();
+      const activeData = await activeRes.json();
+      setProjects(projData.projects ?? []);
+      setActiveProjectId(activeData.project?.id ?? null);
+    } catch {
+      setError("Failed to load projects");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
+
+  const openAddForm = () => {
+    setEditingProject(null);
+    setFormName("");
+    setFormRepoLink("");
+    setShowForm(true);
+    setError(null);
+  };
+
+  const openEditForm = (project: Project) => {
+    setEditingProject(project);
+    setFormName(project.name);
+    setFormRepoLink(project.repoLink);
+    setShowForm(true);
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    if (!formName.trim()) {
+      setError("Project name is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+
+    try {
+      if (editingProject) {
+        const res = await fetch(`/api/projects/${editingProject.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: formName.trim(), repoLink: formRepoLink.trim() }),
+        });
+        if (!res.ok) throw new Error("Failed to update project");
+      } else {
+        const res = await fetch("/api/projects", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: formName.trim(), repoLink: formRepoLink.trim() }),
+        });
+        if (!res.ok) throw new Error("Failed to create project");
+      }
+      setShowForm(false);
+      setEditingProject(null);
+      await fetchProjects();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      const res = await fetch(`/api/projects/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete project");
+      setConfirmDelete(null);
+      await fetchProjects();
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  const handleSetActive = async (id: string) => {
+    try {
+      await fetch("/api/projects/active", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId: id }),
+      });
+      setActiveProjectId(id);
+    } catch {
+      setError("Failed to set active project");
+    }
+  };
+
+  const handleMigrate = async () => {
+    try {
+      const res = await fetch("/api/projects/migrate", { method: "POST" });
+      const data = await res.json();
+      if (data.migrated > 0) {
+        setError(null);
+      }
+    } catch {
+      setError("Migration failed");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-32 text-zinc-500 animate-pulse text-sm">
+        Loading projects...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-zinc-200">Projects</h3>
+        <button
+          onClick={openAddForm}
+          className="px-3 py-1.5 text-xs rounded-md bg-indigo-600 hover:bg-indigo-500 transition-colors"
+        >
+          + Add Project
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-xs text-red-400 bg-red-600/10 px-3 py-1.5 rounded">{error}</p>
+      )}
+
+      {/* Add/Edit form */}
+      {showForm && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4 space-y-3">
+          <h4 className="text-xs font-medium text-zinc-300">
+            {editingProject ? "Edit Project" : "New Project"}
+          </h4>
+          <div>
+            <label className="block text-[10px] text-zinc-500 mb-1">Project Name *</label>
+            <input
+              type="text"
+              value={formName}
+              onChange={(e) => setFormName(e.target.value)}
+              placeholder="My Project"
+              className="w-full px-3 py-2 text-sm bg-zinc-800 border border-zinc-700 rounded-md focus:outline-none focus:border-indigo-500 text-zinc-200 placeholder-zinc-500"
+            />
+          </div>
+          <div>
+            <label className="block text-[10px] text-zinc-500 mb-1">Repository Link</label>
+            <input
+              type="text"
+              value={formRepoLink}
+              onChange={(e) => setFormRepoLink(e.target.value)}
+              placeholder="https://github.com/org/repo"
+              className="w-full px-3 py-2 text-sm bg-zinc-800 border border-zinc-700 rounded-md focus:outline-none focus:border-indigo-500 text-zinc-200 placeholder-zinc-500"
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-2 text-xs rounded-md bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+            >
+              {saving ? "Saving..." : editingProject ? "Update" : "Create"}
+            </button>
+            <button
+              onClick={() => { setShowForm(false); setEditingProject(null); }}
+              className="px-4 py-2 text-xs rounded-md border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Project list */}
+      {projects.length === 0 ? (
+        <div className="p-8 text-center">
+          <p className="text-zinc-500 text-sm mb-3">No projects yet</p>
+          <button
+            onClick={openAddForm}
+            className="px-4 py-2 text-sm rounded-md bg-indigo-600 hover:bg-indigo-500 transition-colors"
+          >
+            Create your first project
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {projects.map((project) => {
+            const isActive = project.id === activeProjectId;
+            return (
+              <div
+                key={project.id}
+                className={`bg-zinc-900 border rounded-lg p-3 ${
+                  isActive ? "border-indigo-600/50" : "border-zinc-800"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-zinc-200 truncate">
+                        {project.name}
+                      </span>
+                      {isActive && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-indigo-600/20 text-indigo-400 border border-indigo-600/30">
+                          Active
+                        </span>
+                      )}
+                    </div>
+                    {project.repoLink && (
+                      <a
+                        href={project.repoLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[10px] text-zinc-500 hover:text-indigo-400 truncate block"
+                      >
+                        {project.repoLink}
+                      </a>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-1 shrink-0">
+                    {!isActive && (
+                      <button
+                        onClick={() => handleSetActive(project.id)}
+                        className="text-[10px] px-2 py-1 rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                      >
+                        Set Active
+                      </button>
+                    )}
+                    <button
+                      onClick={() => openEditForm(project)}
+                      className="text-[10px] px-2 py-1 rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                    >
+                      Edit
+                    </button>
+                    {confirmDelete === project.id ? (
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => handleDelete(project.id)}
+                          className="text-[10px] px-2 py-1 rounded bg-red-600/20 text-red-400 border border-red-600/30 hover:bg-red-600/30 transition-colors"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          onClick={() => setConfirmDelete(null)}
+                          className="text-[10px] px-2 py-1 rounded border border-zinc-700 text-zinc-400 hover:text-zinc-200 transition-colors"
+                        >
+                          No
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmDelete(project.id)}
+                        className="text-[10px] px-2 py-1 rounded border border-zinc-700 text-red-400 hover:bg-red-600/10 transition-colors"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+
+          {/* Migration button — show when there are projects */}
+          <button
+            onClick={handleMigrate}
+            className="text-[10px] text-zinc-600 hover:text-zinc-400 transition-colors"
+          >
+            Migrate unassigned requirements to active project
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/projects/ProjectSelector.tsx
+++ b/src/components/projects/ProjectSelector.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+interface Project {
+  id: string;
+  name: string;
+  repoLink: string;
+}
+
+interface ProjectSelectorProps {
+  /** Current selected project ID */
+  value: string | null;
+  /** Called when user selects a project */
+  onChange: (projectId: string | null) => void;
+  /** Show "All Projects" option */
+  showAll?: boolean;
+  /** Compact variant for inline use */
+  compact?: boolean;
+}
+
+/**
+ * Dropdown selector for switching between projects.
+ * Fetches the project list and active project from the API.
+ */
+export function ProjectSelector({ value, onChange, showAll, compact }: ProjectSelectorProps) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/projects")
+      .then((r) => r.json())
+      .then((d) => {
+        setProjects(d.projects ?? []);
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  if (!loaded || projects.length === 0) return null;
+
+  // Single project — no need to show selector unless showAll is true
+  if (projects.length === 1 && !showAll) return null;
+
+  return (
+    <select
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value || null)}
+      className={`rounded-md border border-zinc-700 bg-zinc-800 text-zinc-300 focus:outline-none focus:ring-1 focus:ring-indigo-600 ${
+        compact ? "px-2 py-1 text-xs" : "px-3 py-1.5 text-sm"
+      }`}
+    >
+      {showAll && <option value="">All Projects</option>}
+      {projects.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/**
+ * Hook to manage the active project state.
+ * Fetches the active project on mount and provides a setter.
+ */
+export function useActiveProject() {
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/projects").then((r) => r.json()),
+      fetch("/api/projects/active").then((r) => r.json()),
+    ])
+      .then(([projData, activeData]) => {
+        setProjects(projData.projects ?? []);
+        setActiveProjectId(activeData.project?.id ?? null);
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  const setActive = useCallback(async (id: string | null) => {
+    setActiveProjectId(id);
+    if (id) {
+      await fetch("/api/projects/active", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId: id }),
+      });
+    }
+  }, []);
+
+  return { activeProjectId, projects, loaded, setActive };
+}

--- a/src/components/widgets/ProjectManagerWidget.tsx
+++ b/src/components/widgets/ProjectManagerWidget.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { ProjectManager } from "@/components/projects/ProjectManager";
+
+/**
+ * Widget wrapper for the project management UI.
+ */
+export function ProjectManagerWidget() {
+  return <ProjectManager />;
+}

--- a/src/components/widgets/RequirementWorkflowWidget.tsx
+++ b/src/components/widgets/RequirementWorkflowWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { RequirementWorkflow } from "@/components/project/RequirementWorkflow";
 
 /**
@@ -11,12 +11,23 @@ import { RequirementWorkflow } from "@/components/project/RequirementWorkflow";
 export function RequirementWorkflowWidget() {
   // Reset key to allow starting a fresh workflow after completing one
   const [workflowKey, setWorkflowKey] = useState(0);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/projects/active")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.project?.id) setActiveProjectId(d.project.id);
+      })
+      .catch(() => {});
+  }, []);
 
   return (
     <div className="min-h-[500px] -m-4 rounded-lg overflow-hidden border border-zinc-800">
       <RequirementWorkflow
         key={workflowKey}
         workflowId={null}
+        activeProjectId={activeProjectId}
         onClose={() => setWorkflowKey((k) => k + 1)}
         onCreated={() => {}}
       />

--- a/src/components/widgets/RequirementsListWidget.tsx
+++ b/src/components/widgets/RequirementsListWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { RequirementsView } from "@/components/project/RequirementsView";
 import { RequirementWorkflow } from "@/components/project/RequirementWorkflow";
 
@@ -12,12 +12,24 @@ export function RequirementsListWidget() {
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [showWorkflow, setShowWorkflow] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+
+  // Load the active project on mount
+  useEffect(() => {
+    fetch("/api/projects/active")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.project?.id) setActiveProjectId(d.project.id);
+      })
+      .catch(() => {});
+  }, []);
 
   if (showWorkflow) {
     return (
       <div className="min-h-[500px] -m-4 rounded-lg overflow-hidden border border-zinc-800">
         <RequirementWorkflow
           workflowId={selectedWorkflowId}
+          activeProjectId={activeProjectId}
           onClose={() => {
             setShowWorkflow(false);
             setSelectedWorkflowId(null);
@@ -32,6 +44,7 @@ export function RequirementsListWidget() {
     <div className="min-h-[400px] -m-4 overflow-hidden">
       <RequirementsView
         key={refreshKey}
+        activeProjectId={activeProjectId}
         onSelectWorkflow={(id) => {
           setSelectedWorkflowId(id);
           setShowWorkflow(true);

--- a/src/components/widgets/WidgetRenderer.tsx
+++ b/src/components/widgets/WidgetRenderer.tsx
@@ -11,6 +11,7 @@ import { RequirementsListWidget } from "./RequirementsListWidget";
 import { RequirementWorkflowWidget } from "./RequirementWorkflowWidget";
 import { AgentStatusWidget } from "./AgentStatusWidget";
 import { TriageSummaryWidget } from "./TriageSummaryWidget";
+import { ProjectManagerWidget } from "./ProjectManagerWidget";
 
 interface WidgetRendererProps {
   config: WidgetConfig;
@@ -44,6 +45,8 @@ export function WidgetRenderer({ config, promptTemplates }: WidgetRendererProps)
         return <AgentStatusWidget />;
       case "triage-summary":
         return <TriageSummaryWidget />;
+      case "project-manager":
+        return <ProjectManagerWidget />;
       default:
         return (
           <p className="text-xs text-zinc-500">

--- a/src/lib/project/workflow.ts
+++ b/src/lib/project/workflow.ts
@@ -51,6 +51,8 @@ export interface WorkflowState {
   creatorRole: string | null;
   /** Role slugs relevant to this requirement (e.g. ["dev", "pm"]) */
   assignedRoles: string[];
+  /** Project this requirement belongs to */
+  projectId: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -76,6 +78,7 @@ export function loadWorkflow(id: string): WorkflowState | null {
     // Backfill fields added after initial schema
     if (!("creatorRole" in raw)) raw.creatorRole = null;
     if (!("assignedRoles" in raw)) raw.assignedRoles = [];
+    if (!("projectId" in raw)) raw.projectId = null;
     return raw;
   } catch {
     return null;
@@ -89,17 +92,14 @@ export function listWorkflows(): WorkflowState[] {
   return files
     .filter((f: string) => f.endsWith(".json"))
     .map((f: string) => {
-      try {
-        return JSON.parse(readFileSync(join(WORKFLOW_DIR, f), "utf-8")) as WorkflowState;
-      } catch {
-        return null;
-      }
+      const id = f.replace(".json", "");
+      return loadWorkflow(id);
     })
     .filter((w): w is WorkflowState => w !== null)
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
 }
 
-export function createWorkflow(options?: { creatorRole?: string; assignedRoles?: string[] }): WorkflowState {
+export function createWorkflow(options?: { creatorRole?: string; assignedRoles?: string[]; projectId?: string }): WorkflowState {
   const id = `wf-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const now = new Date().toISOString();
   const w: WorkflowState = {
@@ -115,6 +115,7 @@ export function createWorkflow(options?: { creatorRole?: string; assignedRoles?:
     pr: null,
     creatorRole: options?.creatorRole ?? null,
     assignedRoles: options?.assignedRoles ?? [],
+    projectId: options?.projectId ?? null,
     createdAt: now,
     updatedAt: now,
   };
@@ -124,9 +125,24 @@ export function createWorkflow(options?: { creatorRole?: string; assignedRoles?:
 
 // ── AI prompt builders ─────────────────────────────────────────────
 
-export function buildGatheringSystemPrompt(): string {
-  return `You are a senior technical product manager AI assistant. Your job is to help the user refine a software requirement into a clear, actionable story.
+export function buildGatheringSystemPrompt(projectContext?: { projectName?: string; repoLink?: string; allProjects?: { id: string; name: string; repoLink: string }[] }): string {
+  let projectInfo = "";
 
+  if (projectContext?.projectName) {
+    projectInfo = `\n\nCURRENT PROJECT: ${projectContext.projectName}${projectContext.repoLink ? ` (${projectContext.repoLink})` : ""}`;
+  }
+
+  if (projectContext?.allProjects && projectContext.allProjects.length > 1 && !projectContext.projectName) {
+    projectInfo = `\n\nAVAILABLE PROJECTS:\n${projectContext.allProjects.map((p) => `- ${p.name}${p.repoLink ? ` (${p.repoLink})` : ""} [id: ${p.id}]`).join("\n")}
+
+PROJECT DETECTION:
+- Analyze the user's requirement to determine which project it belongs to based on keywords, repo references, and context.
+- If you can confidently determine the project, include "[PROJECT_ID:<id>]" in your response (this tag will be hidden from the user).
+- If the requirement could apply to multiple projects or you're unsure, ask the user which project this is for. List the project names for them to choose from.`;
+  }
+
+  return `You are a senior technical product manager AI assistant. Your job is to help the user refine a software requirement into a clear, actionable story.
+${projectInfo}
 RULES:
 - If the user's message is already detailed and actionable (clear goal, scope, and steps), acknowledge the plan briefly and include "[READY_TO_PLAN]" in your FIRST response — do not ask unnecessary questions
 - Only ask clarifying questions when the requirement is genuinely vague or ambiguous

--- a/src/lib/projects/store.ts
+++ b/src/lib/projects/store.ts
@@ -1,0 +1,133 @@
+/**
+ * Multi-project storage.
+ *
+ * Persists projects as JSON in ~/.face/projects.json and tracks the
+ * active project per-user. Each project has an id, name, and repo link.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface Project {
+  id: string;
+  name: string;
+  repoLink: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectStore {
+  projects: Project[];
+  activeProjectId: string | null;
+}
+
+// ── Persistence ────────────────────────────────────────────────────
+
+const FACE_DIR = join(homedir(), ".face");
+const STORE_PATH = join(FACE_DIR, "projects.json");
+
+function ensureDir() {
+  if (!existsSync(FACE_DIR)) mkdirSync(FACE_DIR, { recursive: true });
+}
+
+function readStore(): ProjectStore {
+  ensureDir();
+  if (!existsSync(STORE_PATH)) {
+    return { projects: [], activeProjectId: null };
+  }
+  try {
+    return JSON.parse(readFileSync(STORE_PATH, "utf-8"));
+  } catch {
+    return { projects: [], activeProjectId: null };
+  }
+}
+
+function writeStore(store: ProjectStore) {
+  ensureDir();
+  writeFileSync(STORE_PATH, JSON.stringify(store, null, 2));
+}
+
+// ── CRUD ───────────────────────────────────────────────────────────
+
+export function listProjects(): Project[] {
+  return readStore().projects;
+}
+
+export function getProject(id: string): Project | null {
+  return readStore().projects.find((p) => p.id === id) ?? null;
+}
+
+export function createProject(name: string, repoLink: string): Project {
+  const store = readStore();
+  const now = new Date().toISOString();
+  const project: Project = {
+    id: `proj-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    name,
+    repoLink,
+    createdAt: now,
+    updatedAt: now,
+  };
+  store.projects.push(project);
+
+  // Auto-set as active if it's the first project
+  if (store.projects.length === 1) {
+    store.activeProjectId = project.id;
+  }
+
+  writeStore(store);
+  return project;
+}
+
+export function updateProject(id: string, updates: { name?: string; repoLink?: string }): Project | null {
+  const store = readStore();
+  const project = store.projects.find((p) => p.id === id);
+  if (!project) return null;
+
+  if (updates.name !== undefined) project.name = updates.name;
+  if (updates.repoLink !== undefined) project.repoLink = updates.repoLink;
+  project.updatedAt = new Date().toISOString();
+
+  writeStore(store);
+  return project;
+}
+
+export function deleteProject(id: string): boolean {
+  const store = readStore();
+  const idx = store.projects.findIndex((p) => p.id === id);
+  if (idx === -1) return false;
+
+  store.projects.splice(idx, 1);
+
+  // Clear active if deleted
+  if (store.activeProjectId === id) {
+    store.activeProjectId = store.projects[0]?.id ?? null;
+  }
+
+  writeStore(store);
+  return true;
+}
+
+// ── Active project ─────────────────────────────────────────────────
+
+export function getActiveProjectId(): string | null {
+  return readStore().activeProjectId;
+}
+
+export function setActiveProjectId(id: string | null): boolean {
+  const store = readStore();
+  if (id !== null && !store.projects.find((p) => p.id === id)) {
+    return false;
+  }
+  store.activeProjectId = id;
+  writeStore(store);
+  return true;
+}
+
+export function getActiveProject(): Project | null {
+  const store = readStore();
+  if (!store.activeProjectId) return null;
+  return store.projects.find((p) => p.id === store.activeProjectId) ?? null;
+}

--- a/src/lib/roles/project-views.ts
+++ b/src/lib/roles/project-views.ts
@@ -80,6 +80,12 @@ export const PROJECT_VIEWS: Record<ProjectViewKey, RoleDefinition> = {
         icon: "▦",
         widgets: [{ type: "issue-board", title: "Board", size: "full" }],
       },
+      {
+        key: "projects",
+        label: "Projects",
+        icon: "▣",
+        widgets: [{ type: "project-manager", title: "Projects", size: "full" }],
+      },
     ],
   },
 
@@ -156,6 +162,12 @@ export const PROJECT_VIEWS: Record<ProjectViewKey, RoleDefinition> = {
         label: "Tasks",
         icon: "▤",
         widgets: [{ type: "task-list", title: "Tasks", size: "full" }],
+      },
+      {
+        key: "projects",
+        label: "Projects",
+        icon: "▣",
+        widgets: [{ type: "project-manager", title: "Projects", size: "full" }],
       },
     ],
   },


### PR DESCRIPTION
## Summary
Currently the app supports only a single project. Project managers, developers, testers, and other roles often work across multiple projects simultaneously. This feature adds multi-project support with a setup flow for adding projects (name + repo link) and teaches the AI to detect or ask which project a new requirement belongs to during conversations.

## Acceptance Criteria
- [ ] Users can add a new project from their role view, providing a project name and repo link
- [ ] Users can view a list of all their projects from their role view
- [ ] Users can edit or remove an existing project
- [ ] Users can switch between projects in their role view
- [ ] Requirements are associated with a specific project
- [ ] During requirement conversations, the AI detects which project a requirement belongs to based on context
- [ ] When the AI cannot determine the project, it asks the user to select one
- [ ] Existing single-project data is migrated to the new multi-project structure

## Technical Notes
- Project model (basic version): `{ id, name, repoLink }`
- Requirements need a `projectId` foreign key
- AI project detection can use repo context, keywords, and conversation history to infer the target project
- The project selector should be accessible but not intrusive in the conversation flow
- Consider a default/active project concept so users aren't prompted every time if they primarily work on one project

## Out of Scope
- Extended project metadata (description, tech stack, team members)
- PM tool integration per project (Linear/Jira board linking)
- Cross-project requirement dependencies
- Project-level permissions or role-based access control
- Project archiving or lifecycle management

<sub>Automatically created by FACE for workflow `wf-1774873530327-pk2o`</sub>