### PR TITLE
Add usage tracking and personalized /my page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { UsageTrackerMount } from "@/components/usage/UsageTrackerMount";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,10 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased dark`}
     >
-      <body className="min-h-full bg-zinc-950 text-zinc-100">{children}</body>
+      <body className="min-h-full bg-zinc-950 text-zinc-100">
+        <UsageTrackerMount />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { UserProvider } from "@/components/user/UserContext";
+
+export const metadata: Metadata = {
+  title: "My Dashboard - FACE",
+  description: "Your personalized dashboard sorted by usage frequency.",
+};
+
+export default function MyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <UserProvider>{children}</UserProvider>
+    </div>
+  );
+}

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Suspense } from "react";
+import { MyDashboard } from "@/components/my/MyDashboard";
+
+export default function MyPage() {
+  return (
+    <Suspense>
+      <MyDashboard />
+    </Suspense>
+  );
+}

--- a/src/components/layout/AdaptiveShell.tsx
+++ b/src/components/layout/AdaptiveShell.tsx
@@ -22,12 +22,20 @@ export function AdaptiveShell() {
             </span>
           )}
         </div>
-        <Link
-          href={role === "engineer" ? "/dev" : role === "product_manager" ? "/product-manager" : role === "project_manager" ? "/project-manager" : "/dev"}
-          className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
-        >
-          Role Dashboard
-        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/my"
+            className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            My Dashboard
+          </Link>
+          <Link
+            href={role === "engineer" ? "/dev" : role === "product_manager" ? "/product-manager" : role === "project_manager" ? "/project-manager" : "/dev"}
+            className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            Role Dashboard
+          </Link>
+        </div>
       </header>
 
       <main className="flex-1 flex flex-col p-3 md:p-4 lg:p-6 overflow-hidden">

--- a/src/components/my/MyDashboard.tsx
+++ b/src/components/my/MyDashboard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import { useUsageData } from "@/components/usage/UsageTracker";
+import { getAllPages, type PageInfo } from "@/lib/usage/pages";
+
+/**
+ * Personalized dashboard that reorders feature cards by usage frequency.
+ * Pages the user visits most appear first. Unvisited pages appear in
+ * default registry order at the bottom.
+ */
+export function MyDashboard() {
+  const usageEntries = useUsageData();
+  const allPages = useMemo(() => getAllPages(), []);
+
+  // Build a frequency map from usage data
+  const frequencyMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const entry of usageEntries) {
+      map.set(entry.path, entry.count);
+    }
+    return map;
+  }, [usageEntries]);
+
+  // Sort pages: visited pages by frequency desc, then unvisited in default order
+  const sortedPages = useMemo(() => {
+    const visited: (PageInfo & { count: number })[] = [];
+    const unvisited: PageInfo[] = [];
+
+    for (const page of allPages) {
+      // Skip the /my page itself
+      if (page.path === "/my") continue;
+      const count = frequencyMap.get(page.path);
+      if (count && count > 0) {
+        visited.push({ ...page, count });
+      } else {
+        unvisited.push(page);
+      }
+    }
+
+    visited.sort((a, b) => b.count - a.count);
+    return { visited, unvisited };
+  }, [allPages, frequencyMap]);
+
+  const hasUsageData = sortedPages.visited.length > 0;
+
+  return (
+    <div className="flex h-screen flex-col">
+      <header className="flex items-center justify-between border-b border-zinc-800 px-4 py-3 md:px-6">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/"
+            className="text-sm font-semibold text-zinc-100 hover:text-white transition-colors"
+          >
+            FACE
+          </Link>
+          <span className="text-xs text-zinc-600">My Dashboard</span>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-auto p-4 md:p-6">
+        {hasUsageData && (
+          <section className="mb-8">
+            <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-zinc-500">
+              Most Used
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {sortedPages.visited.map((page) => (
+                <PageCard key={page.path} page={page} count={page.count} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {sortedPages.unvisited.length > 0 && (
+          <section>
+            <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-zinc-500">
+              {hasUsageData ? "Explore" : "All Features"}
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {sortedPages.unvisited.map((page) => (
+                <PageCard key={page.path} page={page} />
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function PageCard({ page, count }: { page: PageInfo; count?: number }) {
+  return (
+    <Link
+      href={page.path}
+      className="group rounded-xl border border-zinc-800 bg-zinc-900/50 p-4 transition-colors hover:border-zinc-700 hover:bg-zinc-900"
+    >
+      <div className="flex items-start gap-3">
+        <svg
+          className="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-400 opacity-70 group-hover:opacity-100 transition-opacity"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d={page.iconPath}
+          />
+        </svg>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium text-zinc-200 truncate group-hover:text-zinc-100">
+              {page.label}
+            </h3>
+            {count != null && (
+              <span className="flex-shrink-0 rounded-full bg-zinc-800 px-1.5 py-0.5 text-[10px] font-medium text-zinc-400">
+                {count} {count === 1 ? "visit" : "visits"}
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-xs text-zinc-500 truncate">
+            {page.description}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/usage/UsageTracker.tsx
+++ b/src/components/usage/UsageTracker.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useCallback, useSyncExternalStore } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import {
+  recordVisit,
+  type UsageEntry,
+  type UsageData,
+  getUsageData,
+} from "@/lib/usage/tracker";
+
+// ── External store for reactive usage data ──────────────────────────
+
+let listeners: Array<() => void> = [];
+let cachedData: UsageData = {};
+
+function subscribe(listener: () => void) {
+  listeners = [...listeners, listener];
+  return () => {
+    listeners = listeners.filter((l) => l !== listener);
+  };
+}
+
+function getSnapshot(): UsageData {
+  return cachedData;
+}
+
+function emitChange() {
+  cachedData = getUsageData();
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+// Initialize on module load (client only)
+if (typeof window !== "undefined") {
+  cachedData = getUsageData();
+}
+
+// ── Hook: subscribe to live usage data ──────────────────────────────
+
+/** Returns usage entries sorted by frequency, updating in real time. */
+export function useUsageData(): UsageEntry[] {
+  const data = useSyncExternalStore(subscribe, getSnapshot, () => ({}) as UsageData);
+  return (Object.entries(data) as [string, { count: number; lastVisited: string }][])
+    .map(([path, entry]) => ({ path, count: entry.count, lastVisited: entry.lastVisited }))
+    .sort((a, b) => b.count - a.count);
+}
+
+// ── Tracker component ───────────────────────────────────────────────
+
+/**
+ * Invisible component that records page visits on every route change.
+ * Mount once near the root layout to capture all navigation.
+ */
+export function UsageTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const track = useCallback(() => {
+    const view = searchParams.get("view");
+    const fullPath = view ? `${pathname}?view=${view}` : pathname;
+    recordVisit(fullPath);
+    emitChange();
+  }, [pathname, searchParams]);
+
+  useEffect(() => {
+    track();
+  }, [track]);
+
+  return null;
+}

--- a/src/components/usage/UsageTrackerMount.tsx
+++ b/src/components/usage/UsageTrackerMount.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Suspense } from "react";
+import { UsageTracker } from "./UsageTracker";
+
+/**
+ * Client-side mount point for the usage tracker.
+ * Wrapped in Suspense because useSearchParams requires it.
+ * Place in root layout to capture all navigation events.
+ */
+export function UsageTrackerMount() {
+  return (
+    <Suspense fallback={null}>
+      <UsageTracker />
+    </Suspense>
+  );
+}

--- a/src/components/widgets/RoleDashboard.tsx
+++ b/src/components/widgets/RoleDashboard.tsx
@@ -127,7 +127,14 @@ export function RoleDashboard({ role }: RoleDashboardProps) {
           </div>
         </nav>
 
-        <div className="border-t border-zinc-800 p-3">
+        <div className="border-t border-zinc-800 p-3 space-y-2">
+          <Link
+            href="/my"
+            className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-zinc-400 hover:bg-zinc-800/50 hover:text-zinc-200 transition-colors"
+          >
+            <span className="text-base">⚡</span>
+            <span className="truncate">My Dashboard</span>
+          </Link>
           <div className="flex items-center gap-2">
             <svg
               className="h-4 w-4 text-blue-400 flex-shrink-0"

--- a/src/lib/usage/pages.ts
+++ b/src/lib/usage/pages.ts
@@ -1,0 +1,54 @@
+import { getAllRoles } from "@/lib/roles/registry";
+
+/**
+ * Describes a navigable page/feature in the application.
+ * Used by the /my dashboard to display feature cards.
+ */
+export interface PageInfo {
+  /** Route path (e.g. "/dev", "/dev?view=issues") */
+  path: string;
+  /** Human-readable label */
+  label: string;
+  /** Short description */
+  description: string;
+  /** SVG icon path data */
+  iconPath: string;
+}
+
+/**
+ * Build a list of all navigable pages from the role registry.
+ * Includes each role's overview page and its sidebar views.
+ */
+export function getAllPages(): PageInfo[] {
+  const pages: PageInfo[] = [];
+
+  // Root page
+  pages.push({
+    path: "/",
+    label: "Home",
+    description: "Setup detection and adaptive shell",
+    iconPath: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0a1 1 0 01-1-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 01-1 1",
+  });
+
+  for (const role of getAllRoles()) {
+    // Role overview
+    pages.push({
+      path: role.routePath,
+      label: role.label,
+      description: role.description,
+      iconPath: role.iconPath,
+    });
+
+    // Sidebar views
+    for (const link of role.sidebarLinks) {
+      pages.push({
+        path: `${role.routePath}?view=${link.key}`,
+        label: `${role.label} — ${link.label}`,
+        description: `${link.label} view in ${role.label} dashboard`,
+        iconPath: role.iconPath,
+      });
+    }
+  }
+
+  return pages;
+}

--- a/src/lib/usage/tracker.ts
+++ b/src/lib/usage/tracker.ts
@@ -1,0 +1,63 @@
+/**
+ * Client-side usage frequency tracker.
+ *
+ * Stores per-route visit counts in localStorage and provides helpers
+ * to record visits, retrieve sorted frequency data, and get all entries.
+ */
+
+const STORAGE_KEY = "face-usage-frequency";
+
+export interface UsageEntry {
+  /** Route path (e.g. "/dev", "/dev?view=issues") */
+  path: string;
+  /** Total visit count */
+  count: number;
+  /** ISO timestamp of last visit */
+  lastVisited: string;
+}
+
+export type UsageData = Record<string, { count: number; lastVisited: string }>;
+
+function readData(): UsageData {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeData(data: UsageData): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // Storage full or unavailable — silently ignore
+  }
+}
+
+/** Record a visit to the given path. */
+export function recordVisit(path: string): UsageData {
+  const data = readData();
+  const existing = data[path];
+  data[path] = {
+    count: (existing?.count ?? 0) + 1,
+    lastVisited: new Date().toISOString(),
+  };
+  writeData(data);
+  return data;
+}
+
+/** Get all usage entries sorted by visit count descending. */
+export function getUsageSorted(): UsageEntry[] {
+  const data = readData();
+  return Object.entries(data)
+    .map(([path, { count, lastVisited }]) => ({ path, count, lastVisited }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/** Get raw usage data. */
+export function getUsageData(): UsageData {
+  return readData();
+}


### PR DESCRIPTION
## Summary
Track which pages and features each user visits across the application and store visit frequency data. Create a new `/my` page that dynamically rearranges its layout based on usage frequency, surfacing the most-used features first.

## Acceptance Criteria
- [ ] Record page/feature visits each time a user navigates to a page
- [ ] Store usage frequency data persistently (per user)
- [ ] Create a new `/my` route accessible from navigation
- [ ] `/my` page displays available features/pages as cards or links
- [ ] Layout automatically reorders based on visit frequency (most used first)
- [ ] Page works correctly on first visit with no usage data (reasonable default order)
- [ ] Usage data updates in real time as the user continues browsing

## Technical Notes
- Use local storage or a lightweight client-side store for usage frequency data initially
- Hook into Next.js route change events to capture page visits without manual instrumentation on each page
- The `/my` page layout should be fully dynamic — no hardcoded arrangement
- Consider a simple frequency counter per route path as the data model

## Out of Scope
- Granular UI element tracking (button clicks, form interactions, modals)
- Server-side analytics or dashboards
- Multi-device sync of usage data
- A/B testing or recommendation algorithms beyond frequency sorting

<sub>Automatically created by FACE for workflow `wf-1774910206114-683y`</sub>