### PR TITLE
Make project switcher global across all role views

### DIFF
--- a/src/app/[role]/layout.tsx
+++ b/src/app/[role]/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getRoleDefinition } from "@/lib/roles/registry";
 import { UserProvider } from "@/components/user/UserContext";
+import { ProjectProvider } from "@/lib/projects/ProjectContext";
 
 export async function generateMetadata({
   params,
@@ -23,7 +24,9 @@ export default function RoleLayout({
 }) {
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
-      <UserProvider>{children}</UserProvider>
+      <ProjectProvider>
+        <UserProvider>{children}</UserProvider>
+      </ProjectProvider>
     </div>
   );
 }

--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { UserProvider } from "@/components/user/UserContext";
+import { ProjectProvider } from "@/lib/projects/ProjectContext";
 
 export const metadata: Metadata = {
   title: "My Dashboard - FACE",
@@ -13,7 +14,9 @@ export default function MyLayout({
 }) {
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
-      <UserProvider>{children}</UserProvider>
+      <ProjectProvider>
+        <UserProvider>{children}</UserProvider>
+      </ProjectProvider>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { SetupFlow } from "@/components/setup/SetupFlow";
 import { AdaptiveShell } from "@/components/layout/AdaptiveShell";
 import { UserProvider } from "@/components/user/UserContext";
+import { ProjectProvider } from "@/lib/projects/ProjectContext";
 
 type AppState = "loading" | "setup" | "ready";
 
@@ -38,8 +39,10 @@ export default function Home() {
   }
 
   return (
-    <UserProvider>
-      <AdaptiveShell />
-    </UserProvider>
+    <ProjectProvider>
+      <UserProvider>
+        <AdaptiveShell />
+      </UserProvider>
+    </ProjectProvider>
   );
 }

--- a/src/components/projects/ProjectManager.tsx
+++ b/src/components/projects/ProjectManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useProjectContext } from "@/lib/projects/ProjectContext";
 
 interface Project {
   id: string;
@@ -15,8 +16,8 @@ interface Project {
  * Used as a widget or standalone view in role dashboards.
  */
 export function ProjectManager() {
+  const { activeProjectId, setActive: setGlobalActive } = useProjectContext();
   const [projects, setProjects] = useState<Project[]>([]);
-  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingProject, setEditingProject] = useState<Project | null>(null);
@@ -28,14 +29,9 @@ export function ProjectManager() {
 
   const fetchProjects = useCallback(async () => {
     try {
-      const [projRes, activeRes] = await Promise.all([
-        fetch("/api/projects"),
-        fetch("/api/projects/active"),
-      ]);
+      const projRes = await fetch("/api/projects");
       const projData = await projRes.json();
-      const activeData = await activeRes.json();
       setProjects(projData.projects ?? []);
-      setActiveProjectId(activeData.project?.id ?? null);
     } catch {
       setError("Failed to load projects");
     } finally {
@@ -110,12 +106,7 @@ export function ProjectManager() {
 
   const handleSetActive = async (id: string) => {
     try {
-      await fetch("/api/projects/active", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ projectId: id }),
-      });
-      setActiveProjectId(id);
+      await setGlobalActive(id);
     } catch {
       setError("Failed to set active project");
     }

--- a/src/components/widgets/RequirementWorkflowWidget.tsx
+++ b/src/components/widgets/RequirementWorkflowWidget.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { RequirementWorkflow } from "@/components/project/RequirementWorkflow";
+import { useProjectContext } from "@/lib/projects/ProjectContext";
 
 /**
  * Widget wrapper for RequirementWorkflow.
@@ -11,16 +12,7 @@ import { RequirementWorkflow } from "@/components/project/RequirementWorkflow";
 export function RequirementWorkflowWidget() {
   // Reset key to allow starting a fresh workflow after completing one
   const [workflowKey, setWorkflowKey] = useState(0);
-  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch("/api/projects/active")
-      .then((r) => r.json())
-      .then((d) => {
-        if (d.project?.id) setActiveProjectId(d.project.id);
-      })
-      .catch(() => {});
-  }, []);
+  const { activeProjectId } = useProjectContext();
 
   return (
     <div className="min-h-[500px] -m-4 rounded-lg overflow-hidden border border-zinc-800">

--- a/src/components/widgets/RequirementsListWidget.tsx
+++ b/src/components/widgets/RequirementsListWidget.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { RequirementsView } from "@/components/project/RequirementsView";
 import { RequirementWorkflow } from "@/components/project/RequirementWorkflow";
+import { useProjectContext } from "@/lib/projects/ProjectContext";
 
 /**
  * Full requirements widget with phase timeline and inline workflow editing.
@@ -12,17 +13,7 @@ export function RequirementsListWidget() {
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [showWorkflow, setShowWorkflow] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
-  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
-
-  // Load the active project on mount
-  useEffect(() => {
-    fetch("/api/projects/active")
-      .then((r) => r.json())
-      .then((d) => {
-        if (d.project?.id) setActiveProjectId(d.project.id);
-      })
-      .catch(() => {});
-  }, []);
+  const { activeProjectId } = useProjectContext();
 
   if (showWorkflow) {
     return (

--- a/src/components/widgets/RoleDashboard.tsx
+++ b/src/components/widgets/RoleDashboard.tsx
@@ -5,7 +5,7 @@ import type { RoleDefinition, SidebarLink } from "@/lib/roles/types";
 import { WidgetRenderer } from "./WidgetRenderer";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useActiveProject } from "@/components/projects/ProjectSelector";
+import { useProjectContext } from "@/lib/projects/ProjectContext";
 
 interface RoleDashboardProps {
   role: RoleDefinition;
@@ -20,7 +20,7 @@ export function RoleDashboard({ role }: RoleDashboardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const viewParam = searchParams.get("view");
-  const { activeProjectId, projects, setActive: setActiveProject } = useActiveProject();
+  const { activeProjectId, projects, setActive: setActiveProject } = useProjectContext();
 
   // Resolve active view: match query param to a sidebar link key, fallback to null (overview)
   const resolveView = useCallback(

--- a/src/lib/projects/ProjectContext.tsx
+++ b/src/lib/projects/ProjectContext.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react";
+
+interface Project {
+  id: string;
+  name: string;
+  repoLink: string;
+}
+
+interface ProjectContextValue {
+  activeProjectId: string | null;
+  projects: Project[];
+  loaded: boolean;
+  setActive: (id: string | null) => Promise<void>;
+}
+
+const ProjectContext = createContext<ProjectContextValue>({
+  activeProjectId: null,
+  projects: [],
+  loaded: false,
+  setActive: async () => {},
+});
+
+export function ProjectProvider({ children }: { children: ReactNode }) {
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/projects").then((r) => r.json()),
+      fetch("/api/projects/active").then((r) => r.json()),
+    ])
+      .then(([projData, activeData]) => {
+        setProjects(projData.projects ?? []);
+        setActiveProjectId(activeData.project?.id ?? null);
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  const setActive = useCallback(async (id: string | null) => {
+    setActiveProjectId(id);
+    if (id) {
+      await fetch("/api/projects/active", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId: id }),
+      });
+    }
+  }, []);
+
+  return (
+    <ProjectContext.Provider value={{ activeProjectId, projects, loaded, setActive }}>
+      {children}
+    </ProjectContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the global project context.
+ * Must be used within a ProjectProvider.
+ */
+export function useProjectContext() {
+  return useContext(ProjectContext);
+}


### PR DESCRIPTION
## Summary
The current project switcher only works on certain pages and is not available in role-specific views (Dev, PM, Designer, etc.). As we are setting up a second project, users need the ability to switch between projects from any view. The switcher should be global and persistent, keeping the user on their current role view when changing projects.

## Acceptance Criteria
- [ ] Project switcher is accessible from all role views (Dev, PM, Designer, etc.)
- [ ] Switching projects keeps the user on their current role view (e.g., stays on Dev view when switching from Project A to Project B)
- [ ] The selected project is reflected consistently across all components and data displayed in the current view
- [ ] Project switcher works with two or more projects configured
- [ ] Views that previously lacked project context now correctly filter/display data for the selected project

## Technical Notes
- The project switcher likely needs to be lifted into a global layout component (sidebar or header) so it persists across route changes
- Project selection state should be stored in a global context or URL parameter so all role views can consume it
- Verify that each role view's data fetching respects the selected project ID
- Check existing `<select>` dropdown in the sidebar and determine if it can be reused or needs to be replaced with a more prominent component

## Out of Scope
- Redesigning the project switcher UI (e.g., search, project metadata preview)
- Per-view or per-widget project context (all views share one global selection)
- Project creation or management workflows
- Onboarding flow for setting up a new project

<sub>Automatically created by FACE for workflow `wf-1774910524222-qutq`</sub>