### PR TITLE
Defer requirement status to 'done' only after PR merge, not on task completion

### DIFF
--- a/src/lib/project/providers/github.ts
+++ b/src/lib/project/providers/github.ts
@@ -160,7 +160,7 @@ export class GitHubProvider implements ProjectProvider {
   }
 
   private buildColumns(issues: Issue[]): Column[] {
-    const statusOrder: IssueStatus[] = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled"];
+    const statusOrder: IssueStatus[] = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled", "failed"];
     const statusNames: Record<IssueStatus, string> = {
       backlog: "Backlog",
       todo: "To Do",
@@ -168,6 +168,7 @@ export class GitHubProvider implements ProjectProvider {
       in_review: "In Review",
       done: "Done",
       cancelled: "Cancelled",
+      failed: "Failed",
     };
 
     return statusOrder.map((status) => ({

--- a/src/lib/project/providers/jira.ts
+++ b/src/lib/project/providers/jira.ts
@@ -35,6 +35,7 @@ function reverseStatus(status: IssueStatus): string {
     case "in_review": return "In Review";
     case "done": return "Done";
     case "cancelled": return "Won't Do";
+    case "failed": return "Won't Do";
     case "backlog": return "Backlog";
   }
 }
@@ -154,7 +155,7 @@ export class JiraProvider implements ProjectProvider {
   }
 
   private buildColumns(issues: Issue[]): Column[] {
-    const statusOrder: IssueStatus[] = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled"];
+    const statusOrder: IssueStatus[] = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled", "failed"];
     const statusNames: Record<IssueStatus, string> = {
       backlog: "Backlog",
       todo: "To Do",
@@ -162,6 +163,7 @@ export class JiraProvider implements ProjectProvider {
       in_review: "In Review",
       done: "Done",
       cancelled: "Cancelled",
+      failed: "Failed",
     };
 
     return statusOrder.map((status) => ({

--- a/src/lib/project/providers/linear.ts
+++ b/src/lib/project/providers/linear.ts
@@ -129,7 +129,7 @@ export class LinearProvider implements ProjectProvider {
   }
 
   private buildColumns(issues: Issue[]): Column[] {
-    const statusOrder: IssueStatus[] = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled"];
+    const statusOrder: IssueStatus[] = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled", "failed"];
     const statusNames: Record<IssueStatus, string> = {
       backlog: "Backlog",
       todo: "To Do",
@@ -137,6 +137,7 @@ export class LinearProvider implements ProjectProvider {
       in_review: "In Review",
       done: "Done",
       cancelled: "Cancelled",
+      failed: "Failed",
     };
 
     return statusOrder.map((status) => ({

--- a/src/lib/project/types.ts
+++ b/src/lib/project/types.ts
@@ -8,7 +8,7 @@
 // ── Core domain types ──────────────────────────────────────────────
 
 export type IssuePriority = "urgent" | "high" | "medium" | "low" | "none";
-export type IssueStatus = "backlog" | "todo" | "in_progress" | "in_review" | "done" | "cancelled";
+export type IssueStatus = "backlog" | "todo" | "in_progress" | "in_review" | "done" | "cancelled" | "failed";
 
 export interface Label {
   id: string;

--- a/src/lib/tasks/github-notify.ts
+++ b/src/lib/tasks/github-notify.ts
@@ -28,8 +28,11 @@ export async function postCompletionComment(task: FaceTask): Promise<void> {
       `[face] Posted completion comment on issue #${task.linkedIssue} for task ${task.id}`
     );
 
-    // Update issue status when task completed successfully
-    if (task.status === "completed") {
+    // Update issue status when task completed successfully.
+    // Tasks with repoInfo are on the PR workflow path — their requirement
+    // status is deferred to "done" only after the PR is merged (handled by
+    // pr-poller). Setting it here would be premature.
+    if (task.status === "completed" && !task.repoInfo) {
       try {
         await provider.updateIssue(String(task.linkedIssue), { status: "done" });
         console.log(`[face] Updated issue #${task.linkedIssue} status to done`);

--- a/src/lib/tasks/runner.ts
+++ b/src/lib/tasks/runner.ts
@@ -6,6 +6,7 @@ import type { FaceTask } from "./types";
 import { postCompletionComment } from "./github-notify";
 import { createPRForCompletedTask } from "../project/pr-creator";
 import { cleanupWorktree, getWorktreeClonePath } from "../project/repo-manager";
+import { getActiveProvider } from "../project/manager";
 export { describeToolUse } from "./describe-tool";
 import { describeToolUse } from "./describe-tool";
 
@@ -357,11 +358,24 @@ function spawnClaudeCode(task: FaceTask, binaryPath: string): void {
     // Post completion comment to linked GitHub issue (fire-and-forget)
     postCompletionComment(task);
 
-    // Auto-create PR for completed implementation tasks (fire-and-forget)
+    // Auto-create PR for completed implementation tasks.
+    // If PR creation fails and the task has a linked issue on the PR path,
+    // mark the requirement as "failed" so it doesn't stay "in progress" forever.
     if (task.status === "completed") {
-      createPRForCompletedTask(task).catch((err) =>
-        console.error(`[face] PR creation failed for task ${task.id}:`, err),
-      );
+      createPRForCompletedTask(task).catch(async (err) => {
+        console.error(`[face] PR creation failed for task ${task.id}:`, err);
+        if (task.linkedIssue && task.repoInfo) {
+          try {
+            const provider = await getActiveProvider();
+            if (provider) {
+              await provider.updateIssue(String(task.linkedIssue), { status: "failed" });
+              console.log(`[face] Set issue #${task.linkedIssue} status to failed after PR creation failure`);
+            }
+          } catch (statusErr) {
+            console.error(`[face] Failed to update issue #${task.linkedIssue} status to failed:`, statusErr);
+          }
+        }
+      });
     }
 
     // Clean up worktree on failure (PR creator handles cleanup on success)


### PR DESCRIPTION
## Summary
Currently, when a task completes and a PR is created from a worktree, `postCompletionComment()` in `github-notify.ts` immediately marks the linked requirement issue as "done." This is premature — the requirement should only be marked "done" after the PR is actually merged. Additionally, if PR creation fails, the requirement should be marked as "failed" rather than "done."

## Acceptance Criteria
- [ ] `postCompletionComment()` in `github-notify.ts` no longer sets requirement status to "done" when the task has a PR workflow path
- [ ] When PR creation succeeds, requirement status remains "in progress" until the PR is merged
- [ ] When PR creation fails, requirement status is set to "failed"
- [ ] When a PR is merged, the PR merge poller (`pr-poller.ts`) sets the requirement status to "done" (existing behavior, verify it still works)
- [ ] Requirements without a PR workflow path (if any exist) are unaffected by this change

## Technical Notes
- `github-notify.ts:32-35`: Remove or gate the `updateIssue` call that sets status to "done" — this should not fire when a PR path is involved
- `runner.ts:358-364`: Task completion triggers `postCompletionComment()` before PR creation; the status update must be deferred
- `runner.ts`: After PR creation attempt (lines 361-364), if PR creation fails, set requirement status to "failed"
- `pr-poller.ts`: Already has correct merge-based "done" logic — verify no regressions

## Out of Scope
- Changes to the PR merge poller's core logic
- Handling of requirements that are not linked to GitHub issues
- UI changes to reflect the new status transitions

<sub>Automatically created by FACE for workflow `wf-1775438287070-lgc9`</sub>