### PR TITLE
Dashboard: Smart top components widget with relative drop cutoff

### DIFF
--- a/src/app/api/components/top/route.ts
+++ b/src/app/api/components/top/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { featureUsageStats } from "@/lib/db/schema";
+import { desc } from "drizzle-orm";
+
+/** If a component's usage is less than this fraction of the one above it, truncate. */
+const RELATIVE_DROP_RATIO = 1 / 3;
+const MIN_COMPONENTS = 3;
+const MAX_COMPONENTS = 5;
+
+export interface TopComponent {
+  featureId: string;
+  interactionCount: number;
+  percentage: number;
+}
+
+/**
+ * Apply relative drop cutoff: starting from rank 2, if usage[i] < usage[i-1] / 3,
+ * truncate at i-1. Enforce floor of 3 and ceiling of 5.
+ */
+function applyRelativeDropCutoff(sorted: { featureId: string; interactionCount: number }[]): typeof sorted {
+  const capped = sorted.slice(0, MAX_COMPONENTS);
+  let cutoffIndex = capped.length;
+
+  for (let i = 1; i < capped.length; i++) {
+    if (capped[i].interactionCount < capped[i - 1].interactionCount * RELATIVE_DROP_RATIO) {
+      cutoffIndex = i;
+      break;
+    }
+  }
+
+  return capped.slice(0, Math.max(MIN_COMPONENTS, cutoffIndex));
+}
+
+export async function GET() {
+  try {
+    const db = getDb();
+    const allStats = db
+      .select({
+        featureId: featureUsageStats.featureId,
+        interactionCount: featureUsageStats.interactionCount,
+      })
+      .from(featureUsageStats)
+      .orderBy(desc(featureUsageStats.interactionCount))
+      .all();
+
+    if (allStats.length === 0) {
+      return NextResponse.json({ components: [] });
+    }
+
+    const totalUsage = allStats.reduce((sum, s) => sum + s.interactionCount, 0);
+    const topSlice = allStats.length < MIN_COMPONENTS ? allStats : applyRelativeDropCutoff(allStats);
+
+    const components: TopComponent[] = topSlice.map((s) => ({
+      featureId: s.featureId,
+      interactionCount: s.interactionCount,
+      percentage: totalUsage > 0 ? Math.round((s.interactionCount / totalUsage) * 100) : 0,
+    }));
+
+    return NextResponse.json({ components });
+  } catch (err) {
+    console.error("[face] Top components error:", err);
+    return NextResponse.json({ error: "Failed to load top components" }, { status: 500 });
+  }
+}

--- a/src/components/my/MyDashboard.tsx
+++ b/src/components/my/MyDashboard.tsx
@@ -4,6 +4,8 @@ import { useMemo } from "react";
 import Link from "next/link";
 import { useUsageData } from "@/components/usage/UsageTracker";
 import { getAllPages, type PageInfo } from "@/lib/usage/pages";
+import { TopComponentsWidget } from "@/components/widgets/TopComponentsWidget";
+import { WidgetShell } from "@/components/widgets/WidgetShell";
 
 /**
  * Personalized dashboard that reorders feature cards by usage frequency.
@@ -60,6 +62,14 @@ export function MyDashboard() {
       </header>
 
       <main className="flex-1 overflow-auto p-4 md:p-6">
+        <section className="mb-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            <WidgetShell title="Top Components" size="medium">
+              <TopComponentsWidget />
+            </WidgetShell>
+          </div>
+        </section>
+
         {hasUsageData && (
           <section className="mb-8">
             <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-zinc-500">

--- a/src/components/widgets/TopComponentsWidget.tsx
+++ b/src/components/widgets/TopComponentsWidget.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+
+interface TopComponent {
+  featureId: string;
+  interactionCount: number;
+  percentage: number;
+}
+
+/**
+ * Displays the top 3–5 most frequently used components,
+ * determined by a relative drop cutoff algorithm.
+ */
+export function TopComponentsWidget() {
+  const [components, setComponents] = useState<TopComponent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/components/top")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.components) setComponents(data.components);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <LoadingSpinner label="Loading top components..." />;
+  }
+
+  if (components.length === 0) {
+    return (
+      <div className="py-4 text-center">
+        <p className="text-xs text-zinc-500">No component usage data yet.</p>
+      </div>
+    );
+  }
+
+  const maxCount = components[0].interactionCount;
+
+  return (
+    <div className="space-y-2">
+      {components.map((c) => (
+        <div
+          key={c.featureId}
+          className="rounded-lg border border-zinc-800 bg-zinc-900/30 p-3"
+        >
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-sm font-medium text-zinc-200 truncate">
+              {formatFeatureId(c.featureId)}
+            </span>
+            <span className="flex-shrink-0 text-xs text-zinc-400">
+              {c.percentage}% ({c.interactionCount})
+            </span>
+          </div>
+          <div className="h-1.5 rounded-full bg-zinc-800">
+            <div
+              className="h-full rounded-full bg-blue-500 transition-all"
+              style={{
+                width: `${maxCount > 0 ? (c.interactionCount / maxCount) * 100 : 0}%`,
+              }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Convert kebab-case feature IDs to readable labels. */
+function formatFeatureId(id: string): string {
+  return id
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/src/components/widgets/WidgetRenderer.tsx
+++ b/src/components/widgets/WidgetRenderer.tsx
@@ -12,6 +12,7 @@ import { RequirementWorkflowWidget } from "./RequirementWorkflowWidget";
 import { AgentStatusWidget } from "./AgentStatusWidget";
 import { TriageSummaryWidget } from "./TriageSummaryWidget";
 import { ProjectManagerWidget } from "./ProjectManagerWidget";
+import { TopComponentsWidget } from "./TopComponentsWidget";
 
 interface WidgetRendererProps {
   config: WidgetConfig;
@@ -47,6 +48,8 @@ export function WidgetRenderer({ config, promptTemplates }: WidgetRendererProps)
         return <TriageSummaryWidget />;
       case "project-manager":
         return <ProjectManagerWidget />;
+      case "top-components":
+        return <TopComponentsWidget />;
       default:
         return (
           <p className="text-xs text-zinc-500">


### PR DESCRIPTION
## Summary
Add a "Top Components" widget to the My Dashboard page that displays the 3–5 most frequently used web page components. The widget uses a relative drop cutoff algorithm so that only meaningfully popular components are shown — if a component's usage rate drops below ~1/3 of the component ranked above it, it and all lower-ranked components are excluded.

## Acceptance Criteria
- [ ] Dashboard displays a top components widget sourced from saved component usage data
- [ ] Widget shows a minimum of 3 and a maximum of 5 components
- [ ] A relative drop cutoff is applied: if a component's usage is less than 1/3 of the one directly above it in rank, that component and all below are excluded
- [ ] If all top 5 components have relatively close usage rates (no relative drop triggers), all 5 are displayed
- [ ] Components are sorted by usage frequency in descending order
- [ ] Each entry shows the component name and its usage percentage or count
- [ ] "New requirement" (and similar high-frequency component types) ranks correctly based on actual usage data
- [ ] Widget handles edge cases gracefully (fewer than 3 components exist, all components have equal usage, etc.)

## Technical Notes
- Data source: the existing saved component usage records — no new data collection needed
- Cutoff algorithm: iterate from rank 1 downward; at each rank `i` (starting from rank 2), if `usage[i] < usage[i-1] / 3`, truncate the list at `i - 1`; enforce a floor of 3 and a ceiling of 5
- The 1/3 ratio threshold should be easy to tune (consider extracting it as a constant)
- Percentages should be calculated against total component usage across the project

## Out of Scope
- Collecting or changing how component usage data is saved
- Click-through navigation from the widget to detailed analytics
- Time-range filtering (e.g., last 7 days vs. all time)
- Customizing which components appear (manual pinning/hiding)

<sub>Automatically created by FACE for workflow `wf-1775530396797-a0im`</sub>