### PR TITLE
Board view does not filter by active project

### DIFF
--- a/src/components/widgets/IssueBoardWidget.tsx
+++ b/src/components/widgets/IssueBoardWidget.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { ProjectFilterSelect } from "@/components/shared/ProjectFilterSelect";
+import { useProjectContext } from "@/lib/projects/ProjectContext";
 
 interface Column {
   id: string;
@@ -20,6 +21,11 @@ interface BoardIssue {
   priority: string;
 }
 
+interface WorkflowRef {
+  issueId: string | null;
+  projectId: string | null;
+}
+
 interface IssueBoardWidgetProps {
   readOnly?: boolean;
 }
@@ -27,7 +33,25 @@ interface IssueBoardWidgetProps {
 export function IssueBoardWidget({ readOnly }: IssueBoardWidgetProps) {
   const [columns, setColumns] = useState<Column[]>([]);
   const [issues, setIssues] = useState<BoardIssue[]>([]);
+  const [issueProjectMap, setIssueProjectMap] = useState<Map<string, string>>(new Map());
   const [loading, setLoading] = useState(true);
+  const { filterProjectId } = useProjectContext();
+
+  // Build an issue→project mapping from workflows
+  useEffect(() => {
+    fetch("/api/project/workflow")
+      .then((r) => r.json())
+      .then((d) => {
+        const map = new Map<string, string>();
+        for (const w of (d.workflows ?? []) as WorkflowRef[]) {
+          if (w.issueId && w.projectId) {
+            map.set(w.issueId, w.projectId);
+          }
+        }
+        setIssueProjectMap(map);
+      })
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     setLoading(true);
@@ -58,6 +82,12 @@ export function IssueBoardWidget({ readOnly }: IssueBoardWidgetProps) {
 
   const issueMap = new Map(issues.map((i) => [i.id, i]));
 
+  // Filter issues by selected project (matching TaskList pattern)
+  const isIssueVisible = (issue: BoardIssue): boolean => {
+    if (filterProjectId === "all") return true;
+    return issueProjectMap.get(issue.id) === filterProjectId;
+  };
+
   return (
     <div>
       <div className="flex items-center justify-end mb-2">
@@ -65,8 +95,9 @@ export function IssueBoardWidget({ readOnly }: IssueBoardWidgetProps) {
       </div>
       <div className={`flex gap-3 overflow-x-auto ${readOnly ? "pointer-events-none" : ""}`}>
         {columns.map((col) => {
-          // Use hydrated issues from the board response if available
-          const colIssues = col.issues ?? col.issueIds.map((id) => issueMap.get(id)).filter(Boolean) as BoardIssue[];
+          // Use hydrated issues from the board response if available, then apply project filter
+          const allColIssues = col.issues ?? col.issueIds.map((id) => issueMap.get(id)).filter(Boolean) as BoardIssue[];
+          const colIssues = allColIssues.filter(isIssueVisible);
           return (
             <div
               key={col.id}


### PR DESCRIPTION
## Summary
The board view (IssueBoardWidget) renders the `ProjectFilterSelect` dropdown but does not actually use the selected project to filter the displayed issues. Other views like RequirementsView and TaskList correctly consume `filterProjectId` from `useProjectContext()` and filter their data accordingly. This results in the board always showing issues from all projects regardless of the selected filter.

## Acceptance Criteria
- [ ] Board view filters displayed issues by the active project selected in `ProjectFilterSelect`
- [ ] Selecting "All" in the project filter shows issues from every project
- [ ] Switching the project filter updates the board columns immediately without a full page reload
- [ ] Board column counts reflect the filtered issue set
- [ ] Drag-and-drop status changes still work correctly when a project filter is active

## Technical Notes
- `IssueBoardWidget` (`src/components/widgets/IssueBoardWidget.tsx`) already renders `<ProjectFilterSelect />` but never calls `useProjectContext()` to read `filterProjectId`
- Follow the same client-side filtering pattern used by `RequirementsView` (line ~119) and `TaskList` (line ~68): consume `filterProjectId` from context, skip items whose `projectId` doesn't match
- The board API route (`src/app/api/project/board/route.ts`) already supports a `projectId` query param — passing it server-side is an alternative approach
- Reference files: `src/components/project/RequirementsView.tsx`, `src/components/tasks/TaskList.tsx`, `src/lib/projects/ProjectContext.tsx`

## Out of Scope
- Adding per-column project filtering or mixed-project columns
- Persisting the selected project filter across sessions
- Changes to the ProjectFilterSelect component itself

<sub>Automatically created by FACE for workflow `wf-1775530625456-btaz`</sub>