### PR TITLE
Fix requirement creation to use selected project's repo instead of defaulting to FACE

### DIFF
--- a/src/app/api/project/setup/chat/route.ts
+++ b/src/app/api/project/setup/chat/route.ts
@@ -7,7 +7,7 @@ import {
   sanitizeForClient,
   type SetupSessionState,
 } from "@/lib/projects/setup";
-import { createProject, setActiveProjectId, listProjects, getProject, DuplicateProjectError, type Project } from "@/lib/projects/store";
+import { createProject, updateProject, setActiveProjectId, listProjects, getProject, DuplicateProjectError, type Project } from "@/lib/projects/store";
 import { addProvider, getActiveProvider, listProviderConfigs } from "@/lib/project/manager";
 import { scaffoldProject, type ScaffoldResult } from "@/lib/projects/scaffold";
 import { readConfig } from "@/lib/tasks/file-manager";
@@ -460,7 +460,13 @@ function getOrCreateProject(
 ): Project {
   if (session.createdProjectId) {
     const existing = getProject(session.createdProjectId);
-    if (existing) return existing;
+    if (existing) {
+      // Update repoLink if a new value is provided and differs from the stored one
+      if (repoLink && existing.repoLink !== repoLink) {
+        return updateProject(existing.id, { repoLink }) ?? existing;
+      }
+      return existing;
+    }
     // Referenced project was deleted — clear the stale reference and try to
     // adopt an existing project with the same name rather than throwing
     session.createdProjectId = null;
@@ -471,7 +477,13 @@ function getOrCreateProject(
         const match = listProjects().find(
           (p) => p.name.toLowerCase() === name.toLowerCase(),
         );
-        if (match) return match;
+        if (match) {
+          // Update repoLink on adopted project if needed
+          if (repoLink && match.repoLink !== repoLink) {
+            return updateProject(match.id, { repoLink }) ?? match;
+          }
+          return match;
+        }
       }
       throw e;
     }
@@ -511,7 +523,7 @@ async function executeActions(session: SetupSessionState, agentReply: string): P
   const name = (actionData.name as string) ?? "Untitled Project";
   const description = (actionData.description as string) ?? "";
   const goals = (actionData.goals as string) ?? "";
-  const repoLink = (actionData.repoLink as string) ?? "";
+  let repoLink = (actionData.repoLink as string) ?? "";
   const pmTool = (actionData.pmTool as string) ?? "local";
 
   // Update session with extracted info
@@ -533,6 +545,12 @@ async function executeActions(session: SetupSessionState, agentReply: string): P
   if (action === "connect_provider") {
     const scope = (actionData.scope as string) ?? "";
     const credentials = (actionData.credentials as Record<string, string>) ?? {};
+
+    // Derive repoLink from scope for GitHub projects when not explicitly provided
+    if (!repoLink && pmTool === "github" && scope) {
+      repoLink = `https://github.com/${scope}`;
+      session.projectInfo.repoLink = repoLink;
+    }
 
     session.scope = scope;
     session.credentials = credentials;
@@ -664,14 +682,13 @@ async function handleLinkProject(
   const name = (actionData.name as string) ?? "Untitled Project";
   const description = (actionData.description as string) ?? "";
   const goals = (actionData.goals as string) ?? "";
-  const repoLink = (actionData.repoLink as string) ?? "";
+  let repoLink = (actionData.repoLink as string) ?? "";
   const pmTool = (actionData.pmTool as string) ?? "local";
   const existingProviderName = (actionData.existingProviderName as string) ?? "";
 
   session.projectInfo.name = name;
   if (description) session.projectInfo.description = description;
   if (goals) session.projectInfo.goals = goals;
-  if (repoLink) session.projectInfo.repoLink = repoLink;
   session.pmTool = pmTool as "github" | "linear" | "jira" | "local";
 
   const providers = listProviderConfigs();
@@ -682,6 +699,12 @@ async function handleLinkProject(
   if (!matchedProvider) {
     return `Could not find the existing provider connection "${existingProviderName}". Please provide credentials to connect.`;
   }
+
+  // Derive repoLink from the matched provider's scope for GitHub projects when not explicitly provided
+  if (!repoLink && pmTool === "github" && matchedProvider.scope) {
+    repoLink = `https://github.com/${matchedProvider.scope}`;
+  }
+  if (repoLink) session.projectInfo.repoLink = repoLink;
 
   const project = getOrCreateProject(session, name, repoLink);
   setActiveProjectId(project.id);

--- a/src/lib/projects/setup-idempotency.test.ts
+++ b/src/lib/projects/setup-idempotency.test.ts
@@ -39,12 +39,13 @@ vi.mock("fs", async () => {
   };
 });
 
-import { createProject, getProject, listProjects } from "./store";
+import { createProject, updateProject, getProject, listProjects } from "./store";
 
 /**
  * Mirrors the getOrCreateProject helper in the setup chat route.
  * Tests the idempotency pattern: if a session already holds a
  * createdProjectId, return the existing project instead of creating a new one.
+ * Also updates repoLink on existing projects when a new value is provided.
  */
 function getOrCreateProject(
   createdProjectId: string | null,
@@ -53,7 +54,12 @@ function getOrCreateProject(
 ) {
   if (createdProjectId) {
     const existing = getProject(createdProjectId);
-    if (existing) return existing;
+    if (existing) {
+      if (repoLink && existing.repoLink !== repoLink) {
+        return updateProject(existing.id, { repoLink }) ?? existing;
+      }
+      return existing;
+    }
   }
   return createProject(name, repoLink);
 }
@@ -91,5 +97,34 @@ describe("setup idempotency guard", () => {
     const project = getOrCreateProject(deletedId, "New Project", "");
     expect(project.name).toBe("New Project");
     expect(project.id).not.toBe(deletedId);
+  });
+
+  it("updates repoLink on existing project when retried with a new value", () => {
+    const first = createProject("Listener", "");
+    expect(first.repoLink).toBe("");
+
+    // Retry with a derived repoLink — should update the existing project
+    const second = getOrCreateProject(first.id, "Listener", "https://github.com/elmtlab/listener");
+    expect(second.id).toBe(first.id);
+    expect(second.repoLink).toBe("https://github.com/elmtlab/listener");
+    expect(listProjects()).toHaveLength(1);
+  });
+
+  it("does not update repoLink when retried with the same value", () => {
+    const first = createProject("Listener", "https://github.com/elmtlab/listener");
+    const originalUpdatedAt = first.updatedAt;
+
+    const second = getOrCreateProject(first.id, "Listener", "https://github.com/elmtlab/listener");
+    expect(second.id).toBe(first.id);
+    expect(second.repoLink).toBe("https://github.com/elmtlab/listener");
+    expect(second.updatedAt).toBe(originalUpdatedAt);
+  });
+
+  it("does not clear repoLink when retried with an empty value", () => {
+    const first = createProject("Listener", "https://github.com/elmtlab/listener");
+
+    const second = getOrCreateProject(first.id, "Listener", "");
+    expect(second.id).toBe(first.id);
+    expect(second.repoLink).toBe("https://github.com/elmtlab/listener");
   });
 });


### PR DESCRIPTION
## Summary
When creating a new requirement and selecting a project (e.g., Listener), the implementation still runs against the FACE repo instead of the selected project's repository. The root cause is that `repoLink` is not derived from the GitHub `scope` field during project setup, leaving it empty, and `resolveWorkingDirectory()` falls back to `process.cwd()`.

## Acceptance Criteria
- [ ] When a project is set up with `pmTool: "github"` and a valid `scope` (e.g., `elmtlab/listener`), `repoLink` is auto-derived as `https://github.com/<scope>` if not explicitly provided
- [ ] `getOrCreateProject()` updates an existing project's `repoLink` when retried with a new value instead of silently ignoring it
- [ ] Selecting the Listener project during requirement creation correctly targets the Listener repo at implementation time
- [ ] Existing projects with missing `repoLink` but valid `scope` are handled correctly without manual data fixes
- [ ] Test coverage for repoLink update behavior in `setup-idempotency.test.ts`

## Technical Notes
- Derive `repoLink` from `scope` in both `executeActions()` and `handleLinkProject()` in `src/app/api/project/setup/chat/route.ts`
- Update `getOrCreateProject()` to overwrite stale `repoLink` on retry
- `resolveWorkingDirectory()` depends on `repoLink` being populated; empty string causes fallback to `process.cwd()`
- The data fix for `~/.face/projects.json` may also be needed for any existing projects created before this code fix

## Out of Scope
- Migrating or backfilling all existing projects with missing repoLinks
- Changes to `resolveWorkingDirectory()` itself
- Support for non-GitHub PM tools

<sub>Automatically created by FACE for workflow `wf-1775956217214-g9ay`</sub>