### PR TITLE
Allow FACE to approve AI agent tool calls from externally-launched Claude Code sessions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,72 @@ _is_running() {
   [ -f "\$PID_FILE" ] && kill -0 "\$(cat "\$PID_FILE")" 2>/dev/null
 }
 
+_setup_hooks_directly() {
+  # Register hooks directly into ~/.claude/settings.json without the server
+  local SETTINGS_DIR="\$HOME/.claude"
+  local SETTINGS_FILE="\$SETTINGS_DIR/settings.json"
+  mkdir -p "\$SETTINGS_DIR"
+
+  if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required for direct hook setup. Install jq and re-run 'face setup'." >&2
+    return 1
+  fi
+
+  # Start with existing settings or empty object
+  local SETTINGS='{}'
+  if [ -f "\$SETTINGS_FILE" ]; then
+    SETTINGS=\$(cat "\$SETTINGS_FILE")
+  fi
+
+  local HOOK_TAG="# face-hook"
+  local BASE_URL="http://localhost:\$PORT"
+  local TASK_URL="\$BASE_URL/api/hooks/task-update"
+  local APPROVAL_URL="\$BASE_URL/api/hooks/tool-approval"
+  local UNREVIEWED_URL="\$BASE_URL/api/hooks/tool-approval/unreviewed"
+
+  # Build the hooks object with jq, removing any existing face hooks first
+  SETTINGS=\$(echo "\$SETTINGS" | jq --arg tag "\$HOOK_TAG" --arg task_url "\$TASK_URL" --arg approval_url "\$APPROVAL_URL" --arg unreviewed_url "\$UNREVIEWED_URL" '
+    # Remove existing face hooks
+    (.hooks // {}) as \$h |
+    (\$h | to_entries | map(
+      .value = (.value | map(select(
+        (.hooks // [] | all(.command // "" | contains(\$tag) | not)) and
+        (.hooks // [] | all(.url // "" | contains("/api/hooks/") | not))
+      )))
+    ) | from_entries) as \$cleaned |
+
+    .hooks = (\$cleaned + {
+      UserPromptSubmit: ((\$cleaned.UserPromptSubmit // []) + [{
+        hooks: [{
+          type: "command",
+          command: (\$tag + "\n[ -n \"$FACE_INTERNAL\" ] && exit 0\ncurl -s -X POST " + \$task_url + " -H '\''Content-Type: application/json'\'' -d \"$(cat | jq -c '\''{hook_type: \"UserPromptSubmit\", session_id: .session_id, prompt: .prompt}'\'')\" > /dev/null 2>&1 || true")
+        }]
+      }]),
+      PostToolUse: ((\$cleaned.PostToolUse // []) + [{
+        hooks: [{
+          type: "command",
+          command: (\$tag + "\n[ -n \"$FACE_INTERNAL\" ] && exit 0\ncurl -s -X POST " + \$task_url + " -H '\''Content-Type: application/json'\'' -d \"$(cat | jq -c '\''{hook_type: \"PostToolUse\", session_id: .session_id, tool_name: .tool_name, tool_input: .tool_input, tool_result: (.tool_result // \"\" | tostring | .[0:500])}'\'')\" > /dev/null 2>&1 || true")
+        }]
+      }]),
+      PreToolUse: ((\$cleaned.PreToolUse // []) + [{
+        hooks: [{
+          type: "command",
+          command: (\$tag + "\n[ -n \"$FACE_INTERNAL\" ] && exit 0\nINPUT=$(cat)\nPAYLOAD=$(echo \"$INPUT\" | jq -c '\''{session_id: .session_id, tool_name: .tool_name, tool_input: .tool_input, cwd: .cwd}'\'')\nRESP=$(curl -s --connect-timeout 10 --max-time 130 -X POST " + \$approval_url + " -H '\''Content-Type: application/json'\'' -d \"$PAYLOAD\" 2>/dev/null)\nRC=$?\nif [ $RC -ne 0 ] || [ -z \"$RESP\" ]; then\n  curl -s --connect-timeout 2 -X POST " + \$unreviewed_url + " -H '\''Content-Type: application/json'\'' -d \"$PAYLOAD\" > /dev/null 2>&1 || true\n  FACE_DIR=\"${HOME}/.face\"\n  mkdir -p \"$FACE_DIR\"\n  echo \"$(date -u +%Y-%m-%dT%H:%M:%SZ) AUTO_APPROVED tool=$(echo \"$INPUT\" | jq -r .tool_name) reason=server_unreachable\" >> \"$FACE_DIR/unreviewed.log\"\n  echo '\''{\"decision\":\"approve\",\"reason\":\"server_unreachable\"}'\''\n  exit 0\nfi\nDECISION=$(echo \"$RESP\" | jq -r '\''.decision // \"approve\"'\'')\nREASON=$(echo \"$RESP\" | jq -r '\''.reason // empty'\'')\nif [ \"$DECISION\" = \"reject\" ]; then\n  if [ -n \"$REASON\" ]; then\n    echo \"{\\\"decision\\\":\\\"block\\\",\\\"reason\\\":\\\"$REASON\\\"}\"\n  else\n    echo '\''{\"decision\":\"block\",\"reason\":\"Rejected by FACE\"}'\''\n  fi\n  exit 2\nfi\necho '\''{\"decision\":\"approve\"}'\''\nexit 0")
+        }]
+      }]),
+      Stop: ((\$cleaned.Stop // []) + [{
+        hooks: [{
+          type: "command",
+          command: (\$tag + "\n[ -n \"$FACE_INTERNAL\" ] && exit 0\ncurl -s -X POST " + \$task_url + " -H '\''Content-Type: application/json'\'' -d \"$(cat | jq -c '\''{hook_type: \"Stop\", session_id: .session_id, stop_reason: .stop_reason, last_assistant_message: (.last_assistant_message // \"\" | tostring | .[0:2000])}'\'')\" > /dev/null 2>&1 || true")
+        }]
+      }])
+    })
+  ')
+
+  echo "\$SETTINGS" > "\$SETTINGS_FILE"
+  echo "Hooks written to \$SETTINGS_FILE"
+}
+
 case "\${1:-start}" in
   start)
     if _is_running; then
@@ -95,18 +161,38 @@ case "\${1:-start}" in
       echo "No log file found."
     fi
     ;;
+  setup)
+    echo "Registering Claude Code hooks..."
+    # Call the FACE setup API if the server is running
+    if _is_running; then
+      RESP=\$(curl -s --connect-timeout 5 -X POST "http://localhost:\$PORT/api/setup/configure" \
+        -H 'Content-Type: application/json' \
+        -d '{"agentId":"claude-code"}' 2>/dev/null)
+      if echo "\$RESP" | grep -q '"success":true'; then
+        echo "Claude Code hooks registered successfully."
+      else
+        echo "Warning: Hook registration via API failed. Response: \$RESP" >&2
+        echo "Falling back to direct settings update..."
+        _setup_hooks_directly
+      fi
+    else
+      echo "FACE server is not running. Configuring hooks directly..."
+      _setup_hooks_directly
+    fi
+    ;;
   -h|--help|help)
-    echo "Usage: face [start|dev|stop|status|logs|help]"
+    echo "Usage: face [start|dev|stop|status|logs|setup|help]"
     echo ""
     echo "  start    Start the dashboard in background (default)"
     echo "  dev      Start in development mode (background)"
     echo "  stop     Stop the running server"
     echo "  status   Check if FACE is running"
     echo "  logs     Tail the server logs"
+    echo "  setup    Register Claude Code hooks (re-run after reinstalling Claude Code)"
     echo "  help     Show this help message"
     ;;
   *)
-    echo "Usage: face [start|dev|stop|status|logs|help]" >&2
+    echo "Usage: face [start|dev|stop|status|logs|setup|help]" >&2
     exit 1
     ;;
 esac
@@ -121,6 +207,16 @@ echo "  face        Start the dashboard (http://localhost:3456)"
 echo "  face dev    Start in development mode"
 echo "  face stop   Stop the running server"
 echo ""
+
+# Auto-register Claude Code hooks
+if command -v jq &>/dev/null; then
+  echo "Registering Claude Code hooks..."
+  "$BIN_DIR/face" setup
+else
+  echo "Note: Install jq to enable automatic Claude Code hook registration."
+  echo "  Then run: face setup"
+  echo ""
+fi
 
 # Remind user to add BIN_DIR to PATH if needed
 if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then

--- a/src/app/api/hooks/tool-approval/[id]/decide/route.ts
+++ b/src/app/api/hooks/tool-approval/[id]/decide/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { decideApproval } from "@/lib/hooks/tool-approval";
+
+/**
+ * POST — Called by the FACE UI to approve or reject a pending tool call.
+ * Body: { decision: "approve" | "reject", reason?: string }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const decision = body.decision === "reject" ? "reject" : "approve";
+    const reason = body.reason ? String(body.reason) : undefined;
+
+    const found = decideApproval(id, decision, reason);
+
+    if (!found) {
+      return NextResponse.json(
+        { error: "Approval request not found or already decided" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ ok: true, decision });
+  } catch (err) {
+    console.error("[face] Decision error:", err);
+    return NextResponse.json(
+      { error: "Failed to process decision" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/hooks/tool-approval/route.ts
+++ b/src/app/api/hooks/tool-approval/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  submitApproval,
+  listPendingApprovals,
+  type ToolApprovalRequest,
+} from "@/lib/hooks/tool-approval";
+
+/**
+ * POST — Called by the PreToolUse hook script.
+ * Registers a pending approval and long-polls until a human decides or timeout.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    const sessionId = String(body.session_id ?? body.sessionId ?? "unknown");
+    const toolName = String(body.tool_name ?? body.toolName ?? "unknown");
+    const toolInput =
+      typeof body.tool_input === "object" && body.tool_input !== null
+        ? body.tool_input
+        : {};
+
+    const approvalRequest: ToolApprovalRequest = {
+      id: `approval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      sessionId,
+      toolName,
+      toolInput,
+      cwd: body.cwd ? String(body.cwd) : undefined,
+      createdAt: new Date().toISOString(),
+    };
+
+    // This blocks until a human decides or the timeout fires
+    const result = await submitApproval(approvalRequest);
+
+    return NextResponse.json({
+      decision: result.decision,
+      reason: result.reason,
+    });
+  } catch (err) {
+    console.error("[face] Tool approval error:", err);
+    // On any error, auto-approve so we don't block the user
+    return NextResponse.json({ decision: "approve", reason: "server_error" });
+  }
+}
+
+/**
+ * GET — Returns the list of currently pending approval requests (for the UI).
+ */
+export async function GET() {
+  return NextResponse.json({ pending: listPendingApprovals() });
+}

--- a/src/app/api/hooks/tool-approval/unreviewed/route.ts
+++ b/src/app/api/hooks/tool-approval/unreviewed/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  logUnreviewedAction,
+  getUnreviewedActions,
+  clearUnreviewedActions,
+} from "@/lib/hooks/tool-approval";
+
+/**
+ * POST — Called by the hook script when the FACE server was unreachable
+ * during the initial approval request but becomes reachable later
+ * (or as a best-effort log from the fallback path).
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+
+    logUnreviewedAction(
+      {
+        id: `unreviewed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        sessionId: String(body.session_id ?? body.sessionId ?? "unknown"),
+        toolName: String(body.tool_name ?? body.toolName ?? "unknown"),
+        toolInput:
+          typeof body.tool_input === "object" && body.tool_input !== null
+            ? body.tool_input
+            : {},
+        cwd: body.cwd ? String(body.cwd) : undefined,
+      },
+      "server_unreachable"
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[face] Unreviewed log error:", err);
+    return NextResponse.json(
+      { error: "Failed to log unreviewed action" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET — Returns all logged unreviewed actions.
+ */
+export async function GET() {
+  return NextResponse.json({ actions: getUnreviewedActions() });
+}
+
+/**
+ * DELETE — Clears the unreviewed actions log after acknowledgment.
+ */
+export async function DELETE() {
+  clearUnreviewedActions();
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/approvals/page.tsx
+++ b/src/app/approvals/page.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { RelativeTime } from "@/components/shared/RelativeTime";
+
+interface PendingApproval {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  createdAt: string;
+}
+
+interface UnreviewedAction {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  reason: string;
+  timestamp: string;
+}
+
+export default function ApprovalsPage() {
+  const [pending, setPending] = useState<PendingApproval[]>([]);
+  const [unreviewed, setUnreviewed] = useState<UnreviewedAction[]>([]);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+  const [deciding, setDeciding] = useState<Set<string>>(new Set());
+
+  const loadPending = useCallback(async () => {
+    try {
+      const res = await fetch("/api/hooks/tool-approval");
+      if (res.ok) {
+        const data = await res.json();
+        setPending(data.pending ?? []);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const loadUnreviewed = useCallback(async () => {
+    try {
+      const res = await fetch("/api/hooks/tool-approval/unreviewed");
+      if (res.ok) {
+        const data = await res.json();
+        setUnreviewed(data.actions ?? []);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPending();
+    loadUnreviewed();
+    const pendingInterval = setInterval(loadPending, 2_000);
+    const unreviewedInterval = setInterval(loadUnreviewed, 10_000);
+    return () => {
+      clearInterval(pendingInterval);
+      clearInterval(unreviewedInterval);
+    };
+  }, [loadPending, loadUnreviewed]);
+
+  async function handleDecision(
+    id: string,
+    decision: "approve" | "reject",
+    reason?: string
+  ) {
+    setDeciding((prev) => new Set(prev).add(id));
+    try {
+      await fetch(`/api/hooks/tool-approval/${id}/decide`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision, reason }),
+      });
+      setPending((prev) => prev.filter((p) => p.id !== id));
+      setExpanded(null);
+      setRejectReason("");
+    } catch (err) {
+      console.error("Failed to submit decision:", err);
+    } finally {
+      setDeciding((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  }
+
+  async function clearUnreviewed() {
+    try {
+      await fetch("/api/hooks/tool-approval/unreviewed", { method: "DELETE" });
+      setUnreviewed([]);
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-zinc-100">
+              Tool Approvals
+            </h1>
+            <p className="text-sm text-zinc-500 mt-1">
+              Review and manage AI agent tool call approvals
+            </p>
+          </div>
+          <a
+            href="/"
+            className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-300 hover:bg-zinc-700 transition-colors"
+          >
+            Back to Dashboard
+          </a>
+        </div>
+
+        {/* Pending approvals */}
+        <section className="mb-10">
+          <h2 className="text-lg font-semibold text-zinc-200 mb-4 flex items-center gap-2">
+            <span className="inline-block h-2 w-2 rounded-full bg-amber-500 animate-pulse" />
+            Pending Approvals
+            {pending.length > 0 && (
+              <span className="text-sm font-normal text-amber-400">
+                ({pending.length})
+              </span>
+            )}
+          </h2>
+
+          {pending.length === 0 ? (
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-6 text-center text-zinc-500">
+              No pending approval requests
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {pending.map((req) => (
+                <div
+                  key={req.id}
+                  className="rounded-xl border border-amber-900/30 bg-amber-950/20 p-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-mono text-sm text-amber-200 font-medium">
+                          {req.toolName}
+                        </span>
+                        <span className="text-xs text-zinc-500 font-mono">
+                          session: {req.sessionId.slice(0, 16)}
+                        </span>
+                        <span className="text-xs text-zinc-600">
+                          <RelativeTime date={req.createdAt} />
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-zinc-400 truncate">
+                        {formatToolInput(req.toolName, req.toolInput)}
+                      </p>
+
+                      {expanded === req.id && (
+                        <div className="mt-3 rounded-lg bg-zinc-900 border border-zinc-700/50 p-4 space-y-2">
+                          <div className="text-xs">
+                            <span className="text-zinc-500">Tool: </span>
+                            <span className="text-zinc-200 font-mono">
+                              {req.toolName}
+                            </span>
+                          </div>
+                          {req.cwd && (
+                            <div className="text-xs">
+                              <span className="text-zinc-500">Directory: </span>
+                              <span className="text-zinc-300 font-mono">
+                                {req.cwd}
+                              </span>
+                            </div>
+                          )}
+                          <div className="text-xs">
+                            <span className="text-zinc-500">Parameters:</span>
+                            <pre className="mt-1 text-zinc-300 font-mono text-[11px] whitespace-pre-wrap break-all max-h-64 overflow-y-auto bg-zinc-950 rounded p-2">
+                              {JSON.stringify(req.toolInput, null, 2)}
+                            </pre>
+                          </div>
+                          <div className="flex items-center gap-2 pt-2">
+                            <input
+                              type="text"
+                              placeholder="Reason for rejection (optional)"
+                              value={rejectReason}
+                              onChange={(e) => setRejectReason(e.target.value)}
+                              className="flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-xs text-zinc-300 placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-red-600"
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <button
+                        onClick={() =>
+                          setExpanded(expanded === req.id ? null : req.id)
+                        }
+                        className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1.5 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
+                      >
+                        {expanded === req.id ? "Less" : "Details"}
+                      </button>
+                      <button
+                        onClick={() =>
+                          handleDecision(
+                            req.id,
+                            "reject",
+                            rejectReason || undefined
+                          )
+                        }
+                        disabled={deciding.has(req.id)}
+                        className="rounded-md border border-red-700 bg-red-950/50 px-4 py-1.5 text-xs font-medium text-red-300 hover:bg-red-900/50 disabled:opacity-50 transition-colors"
+                      >
+                        Reject
+                      </button>
+                      <button
+                        onClick={() => handleDecision(req.id, "approve")}
+                        disabled={deciding.has(req.id)}
+                        className="rounded-md border border-green-700 bg-green-950/50 px-4 py-1.5 text-xs font-medium text-green-300 hover:bg-green-900/50 disabled:opacity-50 transition-colors"
+                      >
+                        Approve
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Unreviewed actions */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-zinc-200 flex items-center gap-2">
+              Unreviewed Actions
+              {unreviewed.length > 0 && (
+                <span className="text-sm font-normal text-zinc-500">
+                  ({unreviewed.length})
+                </span>
+              )}
+            </h2>
+            {unreviewed.length > 0 && (
+              <button
+                onClick={clearUnreviewed}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-xs text-zinc-400 hover:bg-zinc-700 transition-colors"
+              >
+                Clear All
+              </button>
+            )}
+          </div>
+
+          {unreviewed.length === 0 ? (
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-6 text-center text-zinc-500">
+              No unreviewed actions
+            </div>
+          ) : (
+            <div className="rounded-xl border border-zinc-800 bg-zinc-900 overflow-hidden">
+              <div className="px-4 py-3 border-b border-zinc-800 bg-zinc-900/50">
+                <p className="text-xs text-zinc-500">
+                  These tool calls were auto-approved while FACE was offline.
+                  They executed without human review.
+                </p>
+              </div>
+              <div className="divide-y divide-zinc-800/50">
+                {unreviewed.map((action) => (
+                  <div
+                    key={action.id}
+                    className="px-4 py-3 hover:bg-zinc-800/30 transition-colors"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3 min-w-0">
+                        <span className="font-mono text-sm text-zinc-200 flex-shrink-0">
+                          {action.toolName}
+                        </span>
+                        <span className="text-xs text-zinc-500 truncate">
+                          {formatToolInput(action.toolName, action.toolInput)}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-3 flex-shrink-0 text-xs">
+                        <span className="rounded-md bg-amber-950/40 border border-amber-800/30 px-2 py-0.5 text-amber-400">
+                          {action.reason}
+                        </span>
+                        <span className="text-zinc-500">
+                          <RelativeTime date={action.timestamp} />
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function formatToolInput(
+  tool: string,
+  input: Record<string, unknown>
+): string {
+  const t = tool.toLowerCase();
+  if (t === "bash") {
+    return String(input.command ?? input.description ?? "").slice(0, 120);
+  }
+  if (t === "edit" || t === "write" || t === "read") {
+    return String(input.file_path ?? input.filePath ?? "");
+  }
+  if (t === "glob") return `pattern: ${input.pattern ?? ""}`;
+  if (t === "grep") return `search: ${input.pattern ?? ""}`;
+
+  const desc =
+    input.description ?? input.command ?? input.file_path ?? input.pattern;
+  if (desc) return String(desc).slice(0, 120);
+  return JSON.stringify(input).slice(0, 100);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { UsageTrackerMount } from "@/components/usage/UsageTrackerMount";
+import { ToolApprovalBanner } from "@/components/approvals/ToolApprovalBanner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -30,6 +31,7 @@ export default function RootLayout({
     >
       <body className="min-h-full bg-zinc-950 text-zinc-100">
         <UsageTrackerMount />
+        <ToolApprovalBanner />
         {children}
       </body>
     </html>

--- a/src/components/approvals/ToolApprovalBanner.tsx
+++ b/src/components/approvals/ToolApprovalBanner.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+interface PendingApproval {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  createdAt: string;
+}
+
+interface UnreviewedAction {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  reason: string;
+  timestamp: string;
+}
+
+export function ToolApprovalBanner() {
+  const [pending, setPending] = useState<PendingApproval[]>([]);
+  const [unreviewed, setUnreviewed] = useState<UnreviewedAction[]>([]);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [showUnreviewed, setShowUnreviewed] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const loadPending = useCallback(async () => {
+    try {
+      const res = await fetch("/api/hooks/tool-approval");
+      const data = await res.json();
+      setPending(data.pending ?? []);
+    } catch {
+      // Server might not be reachable during development
+    }
+  }, []);
+
+  const loadUnreviewed = useCallback(async () => {
+    try {
+      const res = await fetch("/api/hooks/tool-approval/unreviewed");
+      const data = await res.json();
+      setUnreviewed(data.actions ?? []);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPending();
+    loadUnreviewed();
+    // Poll every 1s for pending (time-sensitive), every 10s for unreviewed
+    const pendingInterval = setInterval(loadPending, 1_000);
+    const unreviewedInterval = setInterval(loadUnreviewed, 10_000);
+    return () => {
+      clearInterval(pendingInterval);
+      clearInterval(unreviewedInterval);
+    };
+  }, [loadPending, loadUnreviewed]);
+
+  async function handleDecision(
+    id: string,
+    decision: "approve" | "reject",
+    reason?: string
+  ) {
+    try {
+      await fetch(`/api/hooks/tool-approval/${id}/decide`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision, reason }),
+      });
+      setPending((prev) => prev.filter((p) => p.id !== id));
+      setExpanded(null);
+      setRejectReason("");
+    } catch (err) {
+      console.error("Failed to submit decision:", err);
+    }
+  }
+
+  async function clearUnreviewed() {
+    try {
+      await fetch("/api/hooks/tool-approval/unreviewed", { method: "DELETE" });
+      setUnreviewed([]);
+      setShowUnreviewed(false);
+    } catch {
+      // ignore
+    }
+  }
+
+  if (pending.length === 0 && unreviewed.length === 0) return null;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50">
+      {/* Pending approvals */}
+      {pending.map((req) => (
+        <div
+          key={req.id}
+          className="border-b border-amber-800/50 bg-amber-950/95 backdrop-blur-sm px-4 py-3"
+        >
+          <div className="max-w-5xl mx-auto">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex items-center gap-1.5 rounded-md bg-amber-900/60 px-2 py-0.5 text-xs font-medium text-amber-300">
+                    <svg
+                      className="h-3 w-3"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                    >
+                      <path d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    Approval Required
+                  </span>
+                  <span className="text-sm font-medium text-amber-100">
+                    {req.toolName}
+                  </span>
+                  <span className="text-xs text-amber-400/60 font-mono truncate">
+                    session: {req.sessionId.slice(0, 12)}
+                  </span>
+                </div>
+
+                {/* Tool input summary */}
+                <p className="mt-1 text-xs text-amber-300/70 truncate">
+                  {formatToolInput(req.toolName, req.toolInput)}
+                </p>
+
+                {/* Expandable details */}
+                {expanded === req.id && (
+                  <div className="mt-2 rounded-md bg-zinc-900/80 border border-zinc-700/50 p-3">
+                    <div className="text-xs text-zinc-400 space-y-1.5">
+                      <div>
+                        <span className="text-zinc-500">Tool:</span>{" "}
+                        <span className="text-zinc-200 font-mono">
+                          {req.toolName}
+                        </span>
+                      </div>
+                      {req.cwd && (
+                        <div>
+                          <span className="text-zinc-500">Directory:</span>{" "}
+                          <span className="text-zinc-300 font-mono">
+                            {req.cwd}
+                          </span>
+                        </div>
+                      )}
+                      <div>
+                        <span className="text-zinc-500">Parameters:</span>
+                        <pre className="mt-1 text-zinc-300 font-mono text-[11px] whitespace-pre-wrap break-all max-h-48 overflow-y-auto">
+                          {JSON.stringify(req.toolInput, null, 2)}
+                        </pre>
+                      </div>
+                      {/* Reject reason input */}
+                      <div className="mt-2 flex items-center gap-2">
+                        <input
+                          type="text"
+                          placeholder="Reason for rejection (optional)"
+                          value={rejectReason}
+                          onChange={(e) => setRejectReason(e.target.value)}
+                          className="flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-300 placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-red-600"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <button
+                  onClick={() =>
+                    setExpanded(expanded === req.id ? null : req.id)
+                  }
+                  className="rounded-md border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
+                >
+                  {expanded === req.id ? "Less" : "Details"}
+                </button>
+                <button
+                  onClick={() =>
+                    handleDecision(req.id, "reject", rejectReason || undefined)
+                  }
+                  className="rounded-md border border-red-700 bg-red-950/50 px-3 py-1 text-xs font-medium text-red-300 hover:bg-red-900/50 transition-colors"
+                >
+                  Reject
+                </button>
+                <button
+                  onClick={() => handleDecision(req.id, "approve")}
+                  className="rounded-md border border-green-700 bg-green-950/50 px-3 py-1 text-xs font-medium text-green-300 hover:bg-green-900/50 transition-colors"
+                >
+                  Approve
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {/* Unreviewed actions notification */}
+      {unreviewed.length > 0 && pending.length === 0 && (
+        <div className="border-b border-zinc-700/50 bg-zinc-900/95 backdrop-blur-sm px-4 py-2">
+          <div className="max-w-5xl mx-auto flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 rounded-md bg-zinc-800 px-2 py-0.5 text-xs font-medium text-zinc-400">
+                <svg
+                  className="h-3 w-3"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {unreviewed.length} unreviewed action
+                {unreviewed.length !== 1 ? "s" : ""}
+              </span>
+              <span className="text-xs text-zinc-500">
+                Auto-approved while FACE was offline
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setShowUnreviewed(!showUnreviewed)}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-300 hover:bg-zinc-700 transition-colors"
+              >
+                {showUnreviewed ? "Hide" : "Review"}
+              </button>
+              <button
+                onClick={clearUnreviewed}
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-400 hover:bg-zinc-700 transition-colors"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+
+          {/* Expanded unreviewed list */}
+          {showUnreviewed && (
+            <div className="max-w-5xl mx-auto mt-2 space-y-1.5 max-h-64 overflow-y-auto pb-2">
+              {unreviewed.map((action) => (
+                <div
+                  key={action.id}
+                  className="rounded-md bg-zinc-800/60 border border-zinc-700/30 px-3 py-2 text-xs"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-zinc-200">
+                        {action.toolName}
+                      </span>
+                      <span className="text-zinc-500">
+                        {formatToolInput(action.toolName, action.toolInput)}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 text-zinc-500">
+                      <span className="text-amber-500/70">{action.reason}</span>
+                      <span>{formatTime(action.timestamp)}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatToolInput(
+  tool: string,
+  input: Record<string, unknown>
+): string {
+  const t = tool.toLowerCase();
+
+  if (t === "bash") {
+    return String(input.command ?? input.description ?? "").slice(0, 120);
+  }
+  if (t === "edit" || t === "write" || t === "read") {
+    return String(input.file_path ?? input.filePath ?? "");
+  }
+  if (t === "glob") {
+    return `pattern: ${input.pattern ?? ""}`;
+  }
+  if (t === "grep") {
+    return `search: ${input.pattern ?? ""}`;
+  }
+
+  const desc =
+    input.description ?? input.command ?? input.file_path ?? input.pattern;
+  if (desc) return String(desc).slice(0, 120);
+
+  return JSON.stringify(input).slice(0, 100);
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString();
+  } catch {
+    return iso;
+  }
+}

--- a/src/components/approvals/ToolApprovalPanel.tsx
+++ b/src/components/approvals/ToolApprovalPanel.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { RelativeTime } from "@/components/shared/RelativeTime";
+
+interface PendingApproval {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  createdAt: string;
+}
+
+const POLL_INTERVAL_MS = 2_000;
+
+export function ToolApprovalPanel() {
+  const [pending, setPending] = useState<PendingApproval[]>([]);
+  const [deciding, setDeciding] = useState<Set<string>>(new Set());
+  const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const fetchPending = useCallback(async () => {
+    try {
+      const res = await fetch("/api/hooks/tool-approval");
+      if (res.ok) {
+        const data = await res.json();
+        setPending(data.pending ?? []);
+      }
+    } catch {
+      // Server may be offline
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPending();
+    const interval = setInterval(fetchPending, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchPending]);
+
+  const handleDecision = useCallback(
+    async (id: string, decision: "approve" | "reject", reason?: string) => {
+      setDeciding((prev) => new Set(prev).add(id));
+      try {
+        await fetch(`/api/hooks/tool-approval/${id}/decide`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ decision, reason }),
+        });
+        setPending((prev) => prev.filter((p) => p.id !== id));
+        setRejectingId(null);
+        setRejectReason("");
+      } catch {
+        // will retry on next poll
+      } finally {
+        setDeciding((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }
+    },
+    []
+  );
+
+  if (pending.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-amber-900/40 bg-gradient-to-br from-amber-950/30 to-orange-950/20 p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" />
+        <h3 className="text-sm font-semibold text-amber-300">
+          Tool Approval Required
+        </h3>
+        <span className="text-xs text-amber-500/70">
+          {pending.length} pending
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        {pending.map((req) => (
+          <div
+            key={req.id}
+            className="rounded-lg border border-zinc-800 bg-zinc-900/80 p-3 space-y-2"
+          >
+            {/* Tool info */}
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-mono font-medium text-zinc-200">
+                    {req.toolName}
+                  </span>
+                  <span className="text-xs text-zinc-600">
+                    <RelativeTime date={req.createdAt} />
+                  </span>
+                </div>
+                {req.cwd && (
+                  <p className="text-xs text-zinc-600 font-mono mt-0.5 truncate">
+                    {req.cwd}
+                  </p>
+                )}
+              </div>
+              <span className="text-xs text-zinc-600 font-mono flex-shrink-0">
+                {req.sessionId.slice(0, 8)}
+              </span>
+            </div>
+
+            {/* Tool input preview */}
+            <ToolInputPreview toolName={req.toolName} input={req.toolInput} />
+
+            {/* Reject reason input */}
+            {rejectingId === req.id && (
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={rejectReason}
+                  onChange={(e) => setRejectReason(e.target.value)}
+                  placeholder="Reason for rejection (optional)"
+                  className="flex-1 rounded-md bg-zinc-800 border border-zinc-700 px-2 py-1 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      handleDecision(req.id, "reject", rejectReason || undefined);
+                    } else if (e.key === "Escape") {
+                      setRejectingId(null);
+                      setRejectReason("");
+                    }
+                  }}
+                />
+                <button
+                  onClick={() =>
+                    handleDecision(req.id, "reject", rejectReason || undefined)
+                  }
+                  disabled={deciding.has(req.id)}
+                  className="rounded-md bg-red-600 hover:bg-red-500 px-3 py-1 text-xs font-medium text-white disabled:opacity-50 transition-colors"
+                >
+                  Confirm
+                </button>
+                <button
+                  onClick={() => {
+                    setRejectingId(null);
+                    setRejectReason("");
+                  }}
+                  className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
+
+            {/* Action buttons */}
+            {rejectingId !== req.id && (
+              <div className="flex items-center gap-2 pt-1">
+                <button
+                  onClick={() => handleDecision(req.id, "approve")}
+                  disabled={deciding.has(req.id)}
+                  className="rounded-md bg-emerald-600 hover:bg-emerald-500 px-4 py-1.5 text-xs font-medium text-white disabled:opacity-50 transition-colors"
+                >
+                  {deciding.has(req.id) ? "..." : "Approve"}
+                </button>
+                <button
+                  onClick={() => {
+                    setRejectingId(req.id);
+                    setRejectReason("");
+                  }}
+                  disabled={deciding.has(req.id)}
+                  className="rounded-md bg-zinc-700 hover:bg-zinc-600 px-4 py-1.5 text-xs font-medium text-zinc-300 disabled:opacity-50 transition-colors"
+                >
+                  Reject
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ToolInputPreview({
+  toolName,
+  input,
+}: {
+  toolName: string;
+  input: Record<string, unknown>;
+}) {
+  const t = toolName.toLowerCase();
+
+  if ((t === "edit" || t === "write" || t === "read") && input.file_path) {
+    return (
+      <div className="rounded bg-zinc-800/60 px-2 py-1.5 text-xs font-mono text-zinc-400 truncate">
+        {String(input.file_path)}
+      </div>
+    );
+  }
+
+  if (t === "bash" && input.command) {
+    return (
+      <div className="rounded bg-zinc-800/60 px-2 py-1.5 text-xs font-mono text-zinc-400 break-all">
+        <span className="text-zinc-600">$ </span>
+        {String(input.command).slice(0, 300)}
+      </div>
+    );
+  }
+
+  if ((t === "grep" || t === "glob") && input.pattern) {
+    return (
+      <div className="rounded bg-zinc-800/60 px-2 py-1.5 text-xs font-mono text-zinc-400">
+        {t}: {String(input.pattern)}
+      </div>
+    );
+  }
+
+  const entries = Object.entries(input).slice(0, 3);
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="rounded bg-zinc-800/60 px-2 py-1.5 text-xs font-mono text-zinc-500 space-y-0.5">
+      {entries.map(([key, value]) => (
+        <div key={key} className="truncate">
+          <span className="text-zinc-600">{key}: </span>
+          {String(value).slice(0, 120)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/approvals/UnreviewedActions.tsx
+++ b/src/components/approvals/UnreviewedActions.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { RelativeTime } from "@/components/shared/RelativeTime";
+
+interface UnreviewedAction {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  reason: string;
+  timestamp: string;
+}
+
+export function UnreviewedActions() {
+  const [actions, setActions] = useState<UnreviewedAction[]>([]);
+  const [expanded, setExpanded] = useState(false);
+  const [clearing, setClearing] = useState(false);
+
+  const fetchActions = useCallback(async () => {
+    try {
+      const res = await fetch("/api/hooks/tool-approval/unreviewed");
+      if (res.ok) {
+        const data = await res.json();
+        setActions(data.actions ?? []);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchActions();
+    const interval = setInterval(fetchActions, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchActions]);
+
+  const handleClear = useCallback(async () => {
+    setClearing(true);
+    try {
+      await fetch("/api/hooks/tool-approval/unreviewed", { method: "DELETE" });
+      setActions([]);
+    } catch {
+      // ignore
+    } finally {
+      setClearing(false);
+    }
+  }, []);
+
+  if (actions.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-zinc-700/50 bg-zinc-900/50 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-zinc-500" />
+          <h3 className="text-sm font-semibold text-zinc-300">
+            Unreviewed Actions
+          </h3>
+          <span className="text-xs text-zinc-600">
+            {actions.length} auto-approved
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+          >
+            {expanded ? "Collapse" : "Expand"}
+          </button>
+          <button
+            onClick={handleClear}
+            disabled={clearing}
+            className="text-xs text-zinc-600 hover:text-zinc-400 disabled:opacity-50 transition-colors"
+          >
+            {clearing ? "Clearing..." : "Dismiss All"}
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="space-y-1.5 max-h-64 overflow-y-auto">
+          {actions.map((action) => (
+            <div
+              key={action.id}
+              className="flex items-center gap-3 rounded-lg bg-zinc-800/40 px-3 py-2 text-xs"
+            >
+              <span className="font-mono font-medium text-zinc-400 flex-shrink-0">
+                {action.toolName}
+              </span>
+              <span className="text-zinc-600 truncate flex-1">
+                {summarizeInput(action.toolName, action.toolInput)}
+              </span>
+              <span className="text-zinc-700 flex-shrink-0">
+                {action.reason}
+              </span>
+              <span className="text-zinc-700 flex-shrink-0">
+                <RelativeTime date={action.timestamp} />
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function summarizeInput(
+  toolName: string,
+  input: Record<string, unknown>
+): string {
+  const t = toolName.toLowerCase();
+  if ((t === "edit" || t === "write" || t === "read") && input.file_path) {
+    return String(input.file_path);
+  }
+  if (t === "bash" && input.command) {
+    return String(input.command).slice(0, 100);
+  }
+  if ((t === "grep" || t === "glob") && input.pattern) {
+    return String(input.pattern);
+  }
+  const firstValue = Object.values(input)[0];
+  return firstValue ? String(firstValue).slice(0, 80) : "";
+}

--- a/src/components/layout/AdaptiveShell.tsx
+++ b/src/components/layout/AdaptiveShell.tsx
@@ -2,6 +2,8 @@
 
 import { TaskList } from "@/components/tasks/TaskList";
 import { TaskSubmit } from "@/components/tasks/TaskSubmit";
+import { ToolApprovalPanel } from "@/components/approvals/ToolApprovalPanel";
+import { UnreviewedActions } from "@/components/approvals/UnreviewedActions";
 import { AdaptiveFeature } from "@/components/shared/AdaptiveFeature";
 import { useUser } from "@/components/user/UserContext";
 import { ROLE_LABELS } from "@/lib/user/types";
@@ -39,6 +41,11 @@ export function AdaptiveShell() {
       </header>
 
       <main className="flex-1 flex flex-col p-3 md:p-4 lg:p-6 overflow-hidden">
+        {/* Pending tool approvals & unreviewed actions */}
+        <div className="mb-4 md:mb-6 space-y-3">
+          <ToolApprovalPanel />
+          <UnreviewedActions />
+        </div>
         {/* Task submission area */}
         <AdaptiveFeature featureId="task-submit" alwaysShow>
           <div className="mb-4 md:mb-6">

--- a/src/lib/agents/setup.ts
+++ b/src/lib/agents/setup.ts
@@ -12,6 +12,8 @@ const CLAUDE_SETTINGS_PATH = path.join(
 );
 
 const FACE_HOOK_URL = `${FACE_BASE_URL}/api/hooks/task-update`;
+const FACE_APPROVAL_URL = `${FACE_BASE_URL}/api/hooks/tool-approval`;
+const FACE_UNREVIEWED_URL = `${FACE_BASE_URL}/api/hooks/tool-approval/unreviewed`;
 
 // We tag our hooks with this command prefix so we can find/remove them later
 const FACE_HOOK_TAG = "# face-hook";
@@ -55,7 +57,7 @@ function isFaceHook(entry: ClaudeHookEntry): boolean {
   return (
     entry.hooks?.some(
       (h) =>
-        h.url?.includes("/api/hooks/task-update") ||
+        h.url?.includes("/api/hooks/") ||
         h.command?.includes(FACE_HOOK_TAG)
     ) ?? false
   );
@@ -102,6 +104,60 @@ export async function setupClaudeCode(): Promise<{
         {
           type: "command",
           command: `${FACE_HOOK_TAG}\n[ -n "$FACE_INTERNAL" ] && exit 0\ncurl -s -X POST ${FACE_HOOK_URL} -H 'Content-Type: application/json' -d "$(cat | jq -c '{hook_type: \"PostToolUse\", session_id: .session_id, tool_name: .tool_name, tool_input: .tool_input, tool_result: (.tool_result // "" | tostring | .[0:500])}')" > /dev/null 2>&1 || true`,
+        },
+      ],
+    });
+
+    // --- PreToolUse: intercepts tool calls for human approval ---
+    if (!settings.hooks.PreToolUse) {
+      settings.hooks.PreToolUse = [];
+    }
+    settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
+      (h) => !isFaceHook(h)
+    );
+    // The hook script:
+    // 1. Posts tool call details to FACE and waits for a decision (up to 10s connect timeout).
+    // 2. If FACE is unreachable, logs the unreviewed action to a local file and auto-approves.
+    // 3. Returns a JSON decision object that Claude Code reads from stdout.
+    settings.hooks.PreToolUse.push({
+      hooks: [
+        {
+          type: "command",
+          command: [
+            FACE_HOOK_TAG,
+            `[ -n "$FACE_INTERNAL" ] && exit 0`,
+            // Read stdin into a variable
+            `INPUT=$(cat)`,
+            // Build the request payload
+            `PAYLOAD=$(echo "$INPUT" | jq -c '{session_id: .session_id, tool_name: .tool_name, tool_input: .tool_input, cwd: .cwd}')`,
+            // Try to reach FACE server (10s connect timeout, 130s max wait)
+            `RESP=$(curl -s --connect-timeout 10 --max-time 130 -X POST ${FACE_APPROVAL_URL} -H 'Content-Type: application/json' -d "$PAYLOAD" 2>/dev/null)`,
+            `RC=$?`,
+            // If curl failed (server unreachable), log unreviewed and auto-approve
+            `if [ $RC -ne 0 ] || [ -z "$RESP" ]; then`,
+            `  curl -s --connect-timeout 2 -X POST ${FACE_UNREVIEWED_URL} -H 'Content-Type: application/json' -d "$PAYLOAD" > /dev/null 2>&1 || true`,
+            `  FACE_DIR="\${HOME}/.face"`,
+            `  mkdir -p "$FACE_DIR"`,
+            `  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) AUTO_APPROVED tool=$(echo "$INPUT" | jq -r .tool_name) reason=server_unreachable" >> "$FACE_DIR/unreviewed.log"`,
+            `  echo '{"decision":"approve","reason":"server_unreachable"}'`,
+            `  exit 0`,
+            `fi`,
+            // Parse the decision from the server response
+            `DECISION=$(echo "$RESP" | jq -r '.decision // "approve"')`,
+            `REASON=$(echo "$RESP" | jq -r '.reason // empty')`,
+            // If rejected, exit 2 to block the tool call
+            `if [ "$DECISION" = "reject" ]; then`,
+            `  if [ -n "$REASON" ]; then`,
+            `    echo "{\\\"decision\\\":\\\"block\\\",\\\"reason\\\":\\\"$REASON\\\"}"`,
+            `  else`,
+            `    echo '{"decision":"block","reason":"Rejected by FACE"}'`,
+            `  fi`,
+            `  exit 2`,
+            `fi`,
+            // Approved
+            `echo '{"decision":"approve"}'`,
+            `exit 0`,
+          ].join("\n"),
         },
       ],
     });

--- a/src/lib/hooks/tool-approval.ts
+++ b/src/lib/hooks/tool-approval.ts
@@ -1,0 +1,164 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ToolApprovalRequest {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  createdAt: string;
+}
+
+export type ToolApprovalDecision = "approve" | "reject";
+
+export interface ToolApprovalResult {
+  decision: ToolApprovalDecision;
+  reason?: string;
+  decidedAt: string;
+}
+
+export interface UnreviewedAction {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  cwd?: string;
+  reason: string; // e.g. "server_unreachable", "timeout"
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory pending approval store
+// ---------------------------------------------------------------------------
+
+interface PendingEntry {
+  request: ToolApprovalRequest;
+  resolve: (result: ToolApprovalResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pending = new Map<string, PendingEntry>();
+
+/** How long to wait for a human decision before auto-approving (ms). */
+const APPROVAL_TIMEOUT_MS = 120_000; // 2 minutes
+
+/**
+ * Register a new approval request and wait for a human decision.
+ *
+ * Returns the decision once a human responds, or auto-approves on timeout.
+ */
+export function submitApproval(
+  request: ToolApprovalRequest
+): Promise<ToolApprovalResult> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      // Auto-approve on timeout and log as unreviewed
+      pending.delete(request.id);
+      const result: ToolApprovalResult = {
+        decision: "approve",
+        reason: "timeout",
+        decidedAt: new Date().toISOString(),
+      };
+      logUnreviewedAction(request, "timeout");
+      resolve(result);
+    }, APPROVAL_TIMEOUT_MS);
+
+    pending.set(request.id, { request, resolve, timer });
+  });
+}
+
+/**
+ * Apply a human decision to a pending approval.
+ */
+export function decideApproval(
+  id: string,
+  decision: ToolApprovalDecision,
+  reason?: string
+): boolean {
+  const entry = pending.get(id);
+  if (!entry) return false;
+
+  clearTimeout(entry.timer);
+  pending.delete(id);
+
+  entry.resolve({
+    decision,
+    reason,
+    decidedAt: new Date().toISOString(),
+  });
+  return true;
+}
+
+/**
+ * List all currently pending approval requests.
+ */
+export function listPendingApprovals(): ToolApprovalRequest[] {
+  return Array.from(pending.values()).map((e) => e.request);
+}
+
+// ---------------------------------------------------------------------------
+// Unreviewed actions log (persisted to ~/.face/unreviewed-actions.json)
+// ---------------------------------------------------------------------------
+
+const UNREVIEWED_PATH = path.join(os.homedir(), ".face", "unreviewed-actions.json");
+
+function readUnreviewedLog(): UnreviewedAction[] {
+  try {
+    if (!fs.existsSync(UNREVIEWED_PATH)) return [];
+    return JSON.parse(fs.readFileSync(UNREVIEWED_PATH, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+function writeUnreviewedLog(actions: UnreviewedAction[]): void {
+  const dir = path.dirname(UNREVIEWED_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(UNREVIEWED_PATH, JSON.stringify(actions, null, 2), "utf-8");
+}
+
+/**
+ * Log an action that was auto-approved without human review.
+ * Called both from the server (timeout) and can be called from the hook
+ * script (server_unreachable) via a separate endpoint.
+ */
+export function logUnreviewedAction(
+  request: Pick<ToolApprovalRequest, "id" | "sessionId" | "toolName" | "toolInput" | "cwd">,
+  reason: string
+): void {
+  const actions = readUnreviewedLog();
+  actions.push({
+    id: request.id,
+    sessionId: request.sessionId,
+    toolName: request.toolName,
+    toolInput: request.toolInput,
+    cwd: request.cwd,
+    reason,
+    timestamp: new Date().toISOString(),
+  });
+  // Keep last 500 entries
+  if (actions.length > 500) {
+    actions.splice(0, actions.length - 500);
+  }
+  writeUnreviewedLog(actions);
+}
+
+/**
+ * Read all unreviewed actions.
+ */
+export function getUnreviewedActions(): UnreviewedAction[] {
+  return readUnreviewedLog();
+}
+
+/**
+ * Clear all unreviewed actions (after user has acknowledged them).
+ */
+export function clearUnreviewedActions(): void {
+  writeUnreviewedLog([]);
+}

--- a/src/lib/pm-sync/types.ts
+++ b/src/lib/pm-sync/types.ts
@@ -49,7 +49,7 @@ export interface PMTaskInput {
   title: string;
   description?: string;
   priority?: "urgent" | "high" | "medium" | "low" | "none";
-  status?: "backlog" | "todo" | "in_progress" | "in_review" | "done" | "cancelled";
+  status?: "backlog" | "todo" | "in_progress" | "in_review" | "done" | "cancelled" | "failed";
   labels?: string[];
 }
 


### PR DESCRIPTION
## Summary
When a user launches Claude Code directly from the terminal (bypassing FACE), FACE should still be able to intercept and present tool call approval requests via a PreToolUse hook. If the FACE server is not running, the hook should auto-approve and log the action so the user's workflow is not blocked.

## Acceptance Criteria
- [ ] A PreToolUse hook is registered in `~/.claude/settings.json` that sends tool call details to the FACE server for approval
- [ ] FACE provides an approval UI where users can review, approve, or reject tool calls from externally-launched Claude Code sessions
- [ ] `./install.sh` automatically registers Claude Code hooks as part of the initial install process
- [ ] A `face setup` CLI subcommand is available to re-register hooks on demand (e.g., after reinstalling Claude Code)
- [ ] When the FACE server is not running, the hook auto-approves the tool call and logs that an unreviewed action occurred
- [ ] Logged unreviewed actions are visible in FACE when the server is next started
- [ ] Running `face setup` on a machine with no prior configuration correctly sets up `~/.claude/settings.json` hooks

## Technical Notes
- FACE already registers hooks in `~/.claude/settings.json` via `setupClaudeCode()` — extend this to include the new PreToolUse hook
- The hook script needs to make an HTTP request to the FACE server, wait for a response (with timeout), and fall back to auto-approve if the server is unreachable
- `face setup` can reuse the existing `setupClaudeCode()` logic, exposed as a CLI entry point in `install.sh`
- Consider a reasonable timeout (e.g., 5-10 seconds) for the hook's HTTP call before falling back to auto-approve
- The approval UI should show tool name, parameters, and session context to help the user make an informed decision

## Out of Scope
- Filtering by risk level (approving only risky tools vs. all tools) — all tool calls go through the same flow for now
- Push notifications or alerts when approval is needed (user must have FACE open)
- Multi-user or remote approval workflows
- Revoking or undoing previously approved actions

<sub>Automatically created by FACE for workflow `wf-1776038007213-i30p`</sub>